### PR TITLE
Add a module for creating ACM certificates.

### DIFF
--- a/acm_certificate/README.md
+++ b/acm_certificate/README.md
@@ -1,0 +1,45 @@
+# `acm_certificate`
+
+This Terraform module is a helper for issuing TLS certificates with Amazon Certificate Manager (ACM) using DNS (Route 53) validation.
+
+Terraform syntax makes it very tricky to get this right when you have conditional resources or multiple subject alternative names.
+
+## Example
+
+```hcl
+resource "aws_route53_zone" "default" {
+  name = "example.com"
+}
+
+module "acm-cert" {
+  source = "github.com/18F/identity-terraform//acm_certificate?ref=master"
+  enabled = 1
+  domain_name = "test.example.com"
+  subject_alternative_names = [
+    "alt1.example.com",
+    "alt2.exampel.com",
+  ]
+  validation_zone_id = "${aws_route53_zone.default.zone_id}"
+}
+
+resource "aws_alb_listener" "ssl" {
+  certificate_arn = "${module.acm-cert.cert_arn}"
+  ...
+}
+```
+
+## Variables
+
+- `domain_name` - The primary domain name on the certificate
+- `enabled` — Like count, but for the whole module. 1 for True, 0 for False
+- `subject_alternative_names` — A list of additional names on the certificate
+- `validation_zone_id` — Route53 zone for validation CNAMEs
+- `validation_cname_ttl` — TTL for the validation CNAMEs
+
+## Outputs
+
+- `cert_arn` — ARN of the issued ACM certificate
+- `finished_id` — Reference this output variable in order to depend on
+  validation being complete. In TF 0.12 you can `depends_on` this variable
+  directly, otherwise you may need a `null_resource`.
+

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -1,0 +1,75 @@
+# -- Variables --
+
+variable "domain_name" {
+  description = "The primary name used on the issued TLS certificate"
+}
+
+variable "enabled" {
+  default = 1
+  description = "Like count, but for the whole module. 1 for True, 0 for False."
+}
+
+variable "subject_alternative_names" {
+  default = []
+  description = "A list of additional names to add to the certificate"
+}
+
+variable "validation_zone_id" {
+  description = "Zone ID used to create the validation CNAMEs"
+}
+
+variable "validation_cname_ttl" {
+  default = 300
+}
+
+# -- Outputs --
+
+output "cert_arn" {
+  description = "ARN of the issued ACM certificate"
+  value = "${element(concat(aws_acm_certificate.main.*.arn, list("")), 0)}"
+}
+
+output "finished_id" {
+  description = "Reference this output in order to depend on validation being complete."
+  value = "${element(concat(aws_acm_certificate_validation.main.*.id, list("")), 0)}"
+}
+
+
+# -- Resources --
+
+
+# Create the certificate with the specified SubjectAltNames
+resource "aws_acm_certificate" "main" {
+  count = "${var.enabled}"
+
+  domain_name               = "${var.domain_name}"
+  subject_alternative_names = "${var.subject_alternative_names}"
+
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Create each validation CNAME
+resource "aws_route53_record" "validation-cnames" {
+  count   = "${(length(var.subject_alternative_names) + 1) * var.enabled}"
+  name    = "${lookup(aws_acm_certificate.main.domain_validation_options[count.index], "resource_record_name")}"
+  type    = "${lookup(aws_acm_certificate.main.domain_validation_options[count.index], "resource_record_type")}"
+  zone_id = "${var.validation_zone_id}"
+  records = ["${lookup(aws_acm_certificate.main.domain_validation_options[count.index], "resource_record_value")}"]
+  ttl     = "${var.validation_cname_ttl}"
+}
+
+# Synthetic Terraform resource that blocks on validation completion
+# You can depend_on this to wait for the ACM cert to be ready.
+resource "aws_acm_certificate_validation" "main" {
+  count = "${var.enabled}"
+
+  certificate_arn = "${aws_acm_certificate.main.arn}"
+
+  validation_record_fqdns = [
+    "${aws_route53_record.validation-cnames.*.fqdn}",
+  ]
+}


### PR DESCRIPTION
This is useful because Terraform has some rather arcane syntax for
referring to lists and arbitrary numbers of SubjectAltNames, so the
module is very helpful to tie it all together including DNS validation
in a convenient way.