### PR TITLE
Add a module for creating launch templates.

### DIFF
--- a/launch_template/README.md
+++ b/launch_template/README.md
@@ -1,0 +1,50 @@
+# EC2 Launch Template Module
+
+This module is a thin wrapper around creating an EC2 launch template in the
+standard Login.gov project format.
+
+https://www.terraform.io/docs/providers/aws/r/launch_template.html
+
+## Usage
+
+Most of the variables are passed through as is to the `launch_template`
+resource. The module automatically adds the appropriate `prefix` and `domain`
+tags according to the provided instance role and domain.
+
+The `ami_id_map` is a mapping of role name to AMI ID. If the role is not
+present in the map, then the `default_ami_id` will be used instead.
+
+```hcl
+module "dbserver_launch_template" {
+  source = "github.com/18F/identity-terraform//launch_template?ref=master"
+
+  role           = "dbserver"
+  env            = "${var.env_name}"
+  root_domain    = "${var.root_domain}"
+  ami_id_map     = "${var.ami_id_map}"
+  default_ami_id = "${local.account_default_ami_id}"
+
+  instance_type             = "c5.large"
+  iam_instance_profile_name = "${aws_iam_instance_profile.dbservers.name}"
+  security_group_ids        = ["${aws_security_group.dbserver.id}", "${aws_security_group.base.id}"]
+
+  user_data                 = "cloud init user data ..."
+
+  template_tags = {
+    tag_for_template = "dbserver v1"
+  }
+
+  block_device_mappings = [
+    {
+      device_name = "/dev/sdg"
+      ebs = [
+        {
+          volume_size = "300"
+          volume_type = "gp2"
+          encrypted = true
+        }
+      ]
+    }
+  ]
+}
+```

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -40,6 +40,14 @@ variable "template_tags" {
   default = {}
 }
 
+variable "block_device_mappings" {
+  description = "EBS or other block devices to map on created instances. https://www.terraform.io/docs/providers/aws/r/launch_template.html#block-devices"
+  type = "list"
+  default = []
+}
+
+# ----
+
 resource "aws_launch_template" "template" {
   name = "${var.env}-${var.role}"
 
@@ -88,6 +96,8 @@ resource "aws_launch_template" "template" {
       var.template_tags
     )
   }"
+
+  block_device_mappings = "${var.block_device_mappings}"
 }
 
 output "template_id" {

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -1,0 +1,84 @@
+variable "role" {
+}
+
+variable "env" {
+  description = "Environment name"
+}
+
+variable "root_domain" {
+}
+
+variable "ami_id_map" {
+  description = "Mapping from role names to AMI IDs"
+  type = "map"
+}
+
+variable "default_ami_id" {
+  description = "AMI ID to use if the role is not found in the map"
+}
+
+variable "instance_type" {
+}
+
+variable "instance_initiated_shutdown_behavior" {
+  default = "terminate"
+}
+
+variable "iam_instance_profile_name" {
+}
+
+variable "user_data" {
+}
+
+variable "security_group_ids" {
+  type = "list"
+}
+
+resource "aws_launch_template" "template" {
+  name = "${var.env}-${var.role}"
+
+  iam_instance_profile {
+    name = "${var.iam_instance_profile_name}"
+  }
+
+  image_id = "${lookup(var.ami_id_map, var.role, var.default_ami_id)}"
+
+  instance_initiated_shutdown_behavior = "${var.instance_initiated_shutdown_behavior}"
+
+  instance_type = "${var.instance_type}"
+
+  user_data = "${var.user_data}"
+
+  monitoring {
+    enabled = true
+  }
+
+  vpc_security_group_ids = ["${var.security_group_ids}"]
+
+  tag_specifications {
+    resource_type = "instance"
+    tags {
+      Name = "asg-${var.env}-${var.role}",
+      prefix = "${var.role}",
+      domain = "${var.env}.${var.root_domain}"
+      env = "${var.env}"
+    }
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags {
+      Name = "asg-${var.env}-${var.role}",
+      prefix = "${var.role}",
+      domain = "${var.env}.${var.root_domain}"
+      env = "${var.env}"
+    }
+  }
+}
+
+output "template_id" {
+  value = "${aws_launch_template.template.id}"
+}
+output "template_name" {
+  value = "${aws_launch_template.template.name}"
+}

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -34,6 +34,12 @@ variable "security_group_ids" {
   type = "list"
 }
 
+variable "template_tags" {
+  description = "Tags to apply to the launch template"
+  type = "map"
+  default = {}
+}
+
 resource "aws_launch_template" "template" {
   name = "${var.env}-${var.role}"
 
@@ -61,7 +67,6 @@ resource "aws_launch_template" "template" {
       Name = "asg-${var.env}-${var.role}",
       prefix = "${var.role}",
       domain = "${var.env}.${var.root_domain}"
-      env = "${var.env}"
     }
   }
 
@@ -71,9 +76,18 @@ resource "aws_launch_template" "template" {
       Name = "asg-${var.env}-${var.role}",
       prefix = "${var.role}",
       domain = "${var.env}.${var.root_domain}"
-      env = "${var.env}"
     }
   }
+
+  tags = "${
+    merge(
+      map(
+        "prefix", "${var.role}",
+        "domain", "${var.env}.${var.root_domain}"
+      ),
+      var.template_tags
+    )
+  }"
 }
 
 output "template_id" {


### PR DESCRIPTION
Launch templates are much like the older ASG Launch Configurations, but they are versioned so that changes don't have to create an entirely new resource, and they can be used to create instances outside an ASG as well as within an ASG.