### PR TITLE
Don't create queue policy if kms logging is not enabled

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -103,7 +103,8 @@ tags = {
     }
 }
 
-resource "aws_sqs_queue_policy" "default"{
+resource "aws_sqs_queue_policy" "default" {
+    count = "${var.kmslogging_service_enabled}"
     queue_url = "${aws_sqs_queue.kms_ct_events.id}"
     policy = "${data.aws_iam_policy_document.sqs_kms_ct_events_policy.json}"
 }


### PR DESCRIPTION
On first deployment when logging isn't enabled, terraform cannot create queue policy due to reference that doesn't exist.  
Error text
* module.kms_logging.data.aws_iam_policy_document.sqs_kms_ct_events_policy: Resource 'aws_cloudwatch_event_rule.decrypt' not found for variable 'aws_cloudwatch_event_rule.decrypt.arn'

Add conditional expression to queue policy creation.