### PR TITLE
Add dashboard and alarm for kms logging

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -12,7 +12,7 @@ data "aws_kms_key" "application"
 
 data "aws_sns_topic" "identity"
 {
-    name = "identity-events"
+    name = "${var.sns_topic_dead_letter}"
 }
 
 locals {

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -53,3 +53,8 @@ variable "ct_queue_maxreceivecount" {
   default = 10
   description = "Number of times a message will be received before going to the deadletter queue"
 }
+
+variable "sns_topic_dead_letter" {
+  description = "SNS topic name for dead letter queue"
+  default = "identity-events"
+}


### PR DESCRIPTION
Add CloudWatch dashboard.  Add alarm for messages on dead letter queue.
https://github.com/18F/identity-devops/issues/1236