### PR TITLE
Terraform infrastructure for both KMS lambdas

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -653,6 +653,9 @@ resource "aws_lambda_function" "cloudtrail-kms" {
       DEBUG = "1"
       LOG_LEVEL = "0"
       DDB_TABLE = "${local.dynamodb_table_name}"
+      RETENTION_DAYS = "365"
+      # An ARN would be nice but to generate the URL we need a name.
+      CT_SQS_QUEUE_NAME = "${aws_sqs_queue.dead_letter.name"}
     }
   }
   
@@ -684,6 +687,7 @@ resource "aws_lambda_function" "cloudwatch-kms" {
       DEBUG = "1"
       LOG_LEVEL = "0"
       DDB_TABLE = "${local.dynamodb_table_name}"
+      RETENTION_DAYS = "365"
     }
   }
   

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -560,6 +560,7 @@ resource "aws_cloudwatch_metric_alarm" "dead_letter" {
     ]
 }
 
+# Allow Lambda to take on a given role.
 data "aws_iam_policy_document" "lambda-assume-role-policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -722,6 +723,7 @@ resource "aws_iam_policy" "lambda-allow-kms-kinesis" {
 EOF
 }
 
+# Note that this policy is NOT applied to the CloudTrail Lambda role.
 resource "aws_iam_role_policy_attachment" "lambda-cloudwatch-kms-kinesis" {
   role       = "${aws_iam_role.lambda-cloudwatch-kms.name}"
   policy_arn = "${aws_iam_policy.lambda-allow-kms-kinesis.arn}"

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -57,3 +57,12 @@ variable "ct_queue_maxreceivecount" {
 variable "sns_topic_dead_letter_arn" {
   description = "SNS topic ARN for dead letter queue"
 }
+
+variable "identity_lambda_functions_gitrev" {
+  default = "bda05730bb1b559c2377ba813145468c1621b742"
+  description = "Initial gitrev of identity-lambda-functions to deploy"
+}
+
+variable "lambda_functions_s3_bucket" {
+  description = "S3 bucket in which Lambda packages are uploaded"
+}

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -59,7 +59,6 @@ variable "sns_topic_dead_letter_arn" {
 }
 
 variable "identity_lambda_functions_gitrev" {
-  default = "bda05730bb1b559c2377ba813145468c1621b742"
   description = "Initial gitrev of identity-lambda-functions to deploy"
 }
 

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -9,7 +9,7 @@ variable "region" {
 
 variable "kmslogging_service_enabled" {
   default = 0
-  description = "Enable KMS Logging service.  If disabled the CloudWatch rule will not be created."
+  description = "Enable KMS Logging service.  If disabled the CloudWatch rules and Lambdas will not be created."
 }
 
 variable "kinesis_shard_count" {


### PR DESCRIPTION
From the main configuration, the user only needs to pass in the S3 bucket for Lambdas (because things outside this module also use it) and a gitrev to start with from identity-lambda-functions.

I am still having Cloudtrail problems in my environment but everything else seems to work.