### PR TITLE
Use the service principal instead of the account principal

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -300,8 +300,10 @@ data "aws_iam_policy_document" "sqs_kms_cw_events_policy" {
         effect = "Allow"
         actions = ["sqs:SendMessage"]
         principals {
-            type        = "AWS"
-            identifiers = ["${data.aws_caller_identity.current.account_id}"]
+            type = "Service"
+            identifiers = [
+                "sns.amazonaws.com"
+            ]
         }
         resources = ["${aws_sqs_queue.kms_cloudwatch_events.arn}"]
         condition {
@@ -349,8 +351,10 @@ data "aws_iam_policy_document" "sqs_kms_es_events_policy" {
         effect = "Allow"
         actions = ["sqs:SendMessage"]
         principals {
-            type        = "AWS"
-            identifiers = ["${data.aws_caller_identity.current.account_id}"]
+            type = "Service"
+            identifiers = [
+                "sns.amazonaws.com"
+            ]
         }
         resources = ["${aws_sqs_queue.kms_elasticsearch_events.arn}"]
         condition {


### PR DESCRIPTION
This appears to be necessary according to https://stackoverflow.com/questions/5926774/sns-topic-not-publishing-to-sqs
AWS documentation wants us to use * as the principal: https://docs.aws.amazon.com/sns/latest/dg/sns-sqs-as-subscriber.html#SendMessageToSQS.sqs.permissions
But I like this way better.