### PR TITLE
Fix event rule firing for every environment

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -204,7 +204,8 @@ resource "aws_cloudwatch_event_rule" "unmatched" {
 
     event_pattern = <<PATTERN
 {
-    "source":["gov.login.app"]
+    "source":["gov.login.app"],
+    "detail": {"environment": ["${var.env_name}"]}
 }
 PATTERN
 }


### PR DESCRIPTION
Add the environment to the event rule.  Currently all of the event rules are matching on the same criteria causing multiple deliveries to the SNS topic.