### PR TITLE
Workaround for TF/AWS bug: Ignore changes in sANs.

### DIFF
--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -49,6 +49,11 @@ resource "aws_acm_certificate" "main" {
 
   lifecycle {
     create_before_destroy = true
+
+    # TODO: this is a workaround for an AWS API / Terraform AWS provider bug
+    # https://github.com/terraform-providers/terraform-provider-aws/issues/8531
+    # https://github.com/18F/identity-devops/issues/1469
+    ignore_changes = ["subject_alternative_names"]
   }
 }
 


### PR DESCRIPTION
Terraform is perpetually recreating certain AWS ACM certificates because
the AWS API has started returning the list of subjectAltNames in a
nondeterministic order.

Work around this for the time being by ignoring changes to the
subjectAltNames. We will need to delete this line if we want to make
changes to the subjectAltNames in the future.

https://github.com/18F/identity-devops/issues/1469