### PR TITLE
Add major new info to cloudwatch ALB dashboard.

### DIFF
--- a/cloudwatch_dashboard_alb/main.tf
+++ b/cloudwatch_dashboard_alb/main.tf
@@ -20,12 +20,35 @@ variable "target_group_arn_suffix" {
     description = "ARN suffix of the target group, used for displaying response time"
 }
 
+variable "asg_name" {
+    description = "Name of the ASG behind the ALB. Used for displaying CPU usage"
+}
+
 variable "vertical_annotations" {
     description = "Raw JSON array of vertical annotations to add to all widgets"
     default = "[]"
 }
 
+variable "region" {
+    description = "AWS region"
+    default = "us-west-2"
+}
+
+variable "response_time_warning_threshold" {
+    description = "Horizontal annotation for warning on response time graph"
+    default = 1
+}
+variable "error_rate_warning_threshold" {
+    description = "Horizontal annotation for warning on error time graph"
+    default = 1
+}
+variable "error_rate_error_threshold" {
+    description = "Horizontal annotation for error on error time graph"
+    default = 5
+}
+
 output "dashboard_arn" {
+    # This hack can go away in TF 0.12
     value = "${element(concat(aws_cloudwatch_dashboard.alb.*.dashboard_arn, list("")), 0)}"
 }
 
@@ -45,13 +68,13 @@ resource "aws_cloudwatch_dashboard" "alb" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/ApplicationELB", "HTTPCode_Target_4XX_Count", "LoadBalancer", "${var.alb_arn_suffix}", { "stat": "Sum", "period": 60 } ],
+                    [ "AWS/ApplicationELB", "HTTPCode_Target_2XX_Count", "LoadBalancer", "${var.alb_arn_suffix}", { "stat": "Sum", "period": 60, "color": "#2ca02c" } ],
                     [ ".", "HTTPCode_Target_3XX_Count", ".", ".", { "stat": "Sum", "period": 60 } ],
-                    [ ".", "HTTPCode_Target_2XX_Count", ".", ".", { "stat": "Sum", "period": 60 } ],
+                    [ ".", "HTTPCode_Target_4XX_Count", ".", ".", { "stat": "Sum", "period": 60, "color": "#1f77b4" } ],
                     [ ".", "HTTPCode_Target_5XX_Count", ".", ".", { "stat": "Sum", "period": 60 } ]
                 ],
-                "region": "us-west-2",
-                "title": "Target HTTP response codes from ${var.target_group_label}",
+                "region": "${var.region}",
+                "title": "Backend target HTTP response codes from ${var.target_group_label}",
                 "period": 300,
                 "yAxis": {
                     "left": {
@@ -59,14 +82,14 @@ resource "aws_cloudwatch_dashboard" "alb" {
                     }
                 },
                 "annotations": {
-                  "vertical": ${var.vertical_annotations}
+                    "vertical": ${var.vertical_annotations}
                 }
             }
         },
         {
             "type": "metric",
             "x": 0,
-            "y": 9,
+            "y": 27,
             "width": 24,
             "height": 6,
             "properties": {
@@ -75,8 +98,8 @@ resource "aws_cloudwatch_dashboard" "alb" {
                 "metrics": [
                     [ "AWS/ApplicationELB", "RequestCount", "LoadBalancer", "${var.alb_arn_suffix}", { "stat": "Sum", "period": 60 } ]
                 ],
-                "region": "us-west-2",
-                "title": "Request volume",
+                "region": "${var.region}",
+                "title": "Backend request volume",
                 "period": 300,
                 "yAxis": {
                     "left": {
@@ -84,7 +107,7 @@ resource "aws_cloudwatch_dashboard" "alb" {
                     }
                 },
                 "annotations": {
-                  "vertical": ${var.vertical_annotations}
+                    "vertical": ${var.vertical_annotations}
                 }
             }
         },
@@ -98,10 +121,13 @@ resource "aws_cloudwatch_dashboard" "alb" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/ApplicationELB", "HTTPCode_ELB_5XX_Count", "LoadBalancer", "${var.alb_arn_suffix}", { "period": 60, "stat": "Sum", "color": "#d62728" } ]
+                    [ "AWS/ApplicationELB", "HTTPCode_ELB_3XX_Count", "LoadBalancer", "${var.alb_arn_suffix}", { "period": 60, "stat": "Sum", "color": "#ff7f0e" } ],
+                    [ ".", "HTTPCode_ELB_4XX_Count", ".", ".", { "period": 60, "stat": "Sum", "color": "#1f77b4" } ],
+                    [ ".", "HTTPCode_ELB_5XX_Count", ".", ".", { "period": 60, "stat": "Sum", "color": "#d62728" } ]
+
                 ],
-                "region": "us-west-2",
-                "title": "5XX errors from ALB",
+                "region": "${var.region}",
+                "title": "Frontend errors from ALB",
                 "period": 300,
                 "yAxis": {
                     "left": {
@@ -109,7 +135,7 @@ resource "aws_cloudwatch_dashboard" "alb" {
                     }
                 },
                 "annotations": {
-                  "vertical": ${var.vertical_annotations}
+                    "vertical": ${var.vertical_annotations}
                 }
             }
         },
@@ -123,10 +149,12 @@ resource "aws_cloudwatch_dashboard" "alb" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/ApplicationELB", "TargetResponseTime", "TargetGroup", "${var.target_group_arn_suffix}", "LoadBalancer", "${var.alb_arn_suffix}", { "stat": "Average" } ]
+                    [ "AWS/ApplicationELB", "TargetResponseTime", "TargetGroup", "${var.target_group_arn_suffix}", "LoadBalancer", "${var.alb_arn_suffix}", { "stat": "p50", "color": "#1f77b4", "label": "p50" } ],
+                    [ "...", { "stat": "p90", "label": "p90" } ],
+                    [ "...", { "stat": "p99", "label": "p99" } ]
                 ],
-                "region": "us-west-2",
-                "title": "Target avg response time",
+                "region": "${var.region}",
+                "title": "Backend response time",
                 "period": 300,
                 "yAxis": {
                     "left": {
@@ -134,7 +162,129 @@ resource "aws_cloudwatch_dashboard" "alb" {
                     }
                 },
                 "annotations": {
-                  "vertical": ${var.vertical_annotations}
+                    "horizontal": [
+                        {
+                            "color": "#d68181",
+                            "value": ${var.response_time_warning_threshold}
+                        }
+                    ],
+                    "vertical": ${var.vertical_annotations}
+                }
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 39,
+            "width": 24,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/AutoScaling", "GroupDesiredCapacity", "AutoScalingGroupName", "${var.asg_name}", { "period": 60, "color": "#c7c7c7", "stat": "Average", "yAxis": "left" } ],
+                    [ ".", "GroupTerminatingInstances", ".", ".", { "period": 60, "color": "#d62728" } ],
+                    [ ".", "GroupPendingInstances", ".", ".", { "period": 60, "color": "#ff7f0e" } ],
+                    [ ".", "GroupInServiceInstances", ".", ".", { "period": 60, "color": "#2ca02c" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    }
+                },
+                "title": "Instance counts: ASG ${var.asg_name}",
+                "period": 300
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 33,
+            "width": 24,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/EC2", "CPUUtilization", "AutoScalingGroupName", "${var.asg_name}", { "period": 60 } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "title": "Average CPU Utilization: ASG ${var.asg_name}",
+                "period": 300,
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "max": 100
+                    }
+                }
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 45,
+            "width": 24,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/ApplicationELB", "UnHealthyHostCount", "TargetGroup", "${var.target_group_arn_suffix}", "LoadBalancer", "${var.alb_arn_suffix}", { "period": 60, "color": "#d62728" } ],
+                    [ ".", "HealthyHostCount", ".", ".", ".", ".", { "period": 60, "color": "#2ca02c" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": true,
+                "region": "${var.region}",
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    }
+                },
+                "title": "ELB health check results (stacked)"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 9,
+            "width": 24,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "(target_errs + elb_5xx) / (elb_3xx + elb_4xx + elb_5xx + target_total) * 100", "label": "Overall Error Rate", "id": "err_rate", "color": "#9467bd", "visible": false } ],
+                    [ { "expression": "(target_errs / target_total) * 100", "label": "Backend Error Rate", "id": "target_err_rate", "color": "#d62728", "period": 60, "stat": "Sum" } ],
+                    [ { "expression": "elb_5xx / (elb_3xx + elb_4xx + elb_5xx + target_total) * 100", "label": "ELB Frontend Error Rate", "id": "elb_err_rate", "color": "#000" } ],
+                    [ "AWS/ApplicationELB", "RequestCount", "LoadBalancer", "${var.alb_arn_suffix}", { "id": "target_total", "label": "Backend RequestCount", "color": "#1f77b4", "period": 60, "stat": "Sum", "yAxis": "right", "visible": false } ],
+                    [ ".", "HTTPCode_Target_5XX_Count", ".", ".", { "period": 60, "stat": "Sum", "id": "target_errs", "yAxis": "right", "visible": false, "color": "#ffbb78" } ],
+                    [ ".", "HTTPCode_ELB_3XX_Count", ".", ".", { "period": 60, "stat": "Sum", "id": "elb_3xx", "yAxis": "right", "visible": false, "color": "#c49c94" } ],
+                    [ ".", "HTTPCode_ELB_4XX_Count", ".", ".", { "period": 60, "stat": "Sum", "id": "elb_4xx", "yAxis": "right", "visible": false, "color": "#bcbd22" } ],
+                    [ ".", "HTTPCode_ELB_5XX_Count", ".", ".", { "period": 60, "stat": "Sum", "id": "elb_5xx", "yAxis": "right", "visible": false, "color": "#c5b0d5" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "yAxis": {
+                    "left": {
+                        "label": "Percent",
+                        "showUnits": false,
+                        "min": 0
+                    }
+                },
+                "title": "Error rate",
+                "period": 300,
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "color": "#ffbb80",
+                            "value": ${var.error_rate_warning_threshold}
+                        },
+                        {
+                            "color": "#d68181",
+                            "value": ${var.error_rate_error_threshold}
+                        }
+                    ]
+                },
+                "legend": {
+                    "position": "bottom"
                 }
             }
         }


### PR DESCRIPTION
Refactor the ALB dashboard to provide significantly more useful
information, especially for CPU-based autoscaling.

- Factor out the region to a variable so this module is region-independent.

- Tweak labels to emphasize which metrics are frontend ELB vs backend
  target group metrics.

- On frontend ELB errors graph, show 3xx and 4xx errors in addition to
  5xx. This will allow us to better notice things like the WAF blocking
  requests and returning 4xx errors.

- On response time graph, remove the mean graph line and replace it with
  p50, p90, and p99 lines. Percentiles are much more representative of
  the underlying data, especially for our use case. Our response time
  histogram is bimodal: most requests are for static assets served by
  nginx, and response time is extremely fast. But a significant
  proportion of requests are served by the rails app, and these are much
  slower (closer to the 90th percentile).
  The mean was misleadingly high for nginx requests and misleadingly low
  for rails requests. Percentiles are much more accurate and will allow
  us to more easily see trends that only appear in the 99th percentile.

- Add new graphs of several metrics related to auto scaling:
    - Graph the average CPU across the entire ASG. This will likely be
      our metric for CPU target-based autoscaling.
    - Graph the current ASG instance counts: Desired, InService,
      Pending, and Terminated. This will make ASG actions more obvious.
    - Graph the current ELB health check statuses on a stacked chart.
      This makes it obvious at a glance when instances are considered
      unhealthy by the ELB.

- Add a new graph of error rate. It is now possible in CloudWatch to
  graph composite metrics that are a mathematical expression combining
  several raw metrics. We can thus use this to show error rate.
    - Display separate frontend and backend error rates to make it extra
      obvious when a problem is due to the application versus when there
      are no healthy instances at all.