### PR TITLE
If default is specified, type field is inferred

### DIFF
--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -36,13 +36,11 @@ variable "security_group_ids" {
 
 variable "template_tags" {
   description = "Tags to apply to the launch template"
-  type = "map"
   default = {}
 }
 
 variable "block_device_mappings" {
   description = "EBS or other block devices to map on created instances. https://www.terraform.io/docs/providers/aws/r/launch_template.html#block-devices"
-  type = "list"
   default = []
 }
 


### PR DESCRIPTION
This aligns with other usages of list and map, ex: `acm_certificate/main.tf` and `cloudwatch_dashboard_alb/main.tf`

Behavior noted at: https://www.terraform.io/docs/configuration-0-11/variables.html