### PR TITLE
Terraform v0.12 upgrade

### DIFF
--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -69,7 +69,7 @@ resource "aws_route53_record" "validation-cnames" {
   # If the expression in the following list itself returns a list, remove the
   # brackets to avoid interpretation as a list of lists. If the expression
   # returns a single list item then leave it as-is and remove this TODO comment.
-  records = [aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_value"]]
+  records = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_value"]
   ttl     = var.validation_cname_ttl
 }
 

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -4,6 +4,7 @@ variable "domain_name" {
   description = "The primary name used on the issued TLS certificate"
 }
 
+# TODO: convert to bool
 variable "enabled" {
   default     = 1
   description = "Like count, but for the whole module. 1 for True, 0 for False."
@@ -57,12 +58,12 @@ resource "aws_acm_certificate" "main" {
 
 # Create each validation CNAME
 resource "aws_route53_record" "validation-cnames" {
-  count = length(var.subject_alternative_names) + 1 * var.enabled
+  count = var.enabled == 1 ? length(var.subject_alternative_names) + 1 : 0
 
-  name    = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_name"]
-  type    = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_type"]
+  name    = aws_acm_certificate.main[0].domain_validation_options[count.index]["resource_record_name"]
+  type    = aws_acm_certificate.main[0].domain_validation_options[count.index]["resource_record_type"]
   zone_id = var.validation_zone_id
-  records = [aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_value"]]
+  records = [aws_acm_certificate.main[0].domain_validation_options[count.index]["resource_record_value"]]
   ttl     = var.validation_cname_ttl
 }
 

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -60,10 +60,10 @@ resource "aws_acm_certificate" "main" {
 # Create each validation CNAME
 resource "aws_route53_record" "validation-cnames" {
   count   = (length(var.subject_alternative_names) + 1) * var.enabled
-  name    = lookup(aws_acm_certificate.main[count.index].domain_validation_options[count.index], "resource_record_name")
-  type    = lookup(aws_acm_certificate.main[count.index].domain_validation_options[count.index], "resource_record_type")
+  name    = aws_acm_certificate.main[0].domain_validation_options[count.index].resource_record_name
+  type    = aws_acm_certificate.main[0].domain_validation_options[count.index].resource_record_type
   zone_id = var.validation_zone_id
-  records = [lookup(aws_acm_certificate.main[count.index].domain_validation_options[count.index], "resource_record_value")]
+  records = [aws_acm_certificate.main[0].domain_validation_options[count.index].resource_record_value]
   ttl     = var.validation_cname_ttl
 }
 
@@ -74,7 +74,5 @@ resource "aws_acm_certificate_validation" "main" {
 
   certificate_arn = aws_acm_certificate.main[count.index].arn
 
-  validation_record_fqdns = [
-    "${aws_route53_record.validation-cnames.*.fqdn}",
-  ]
+  validation_record_fqdns = aws_route53_record.validation-cnames[*].fqdn
 }

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -5,12 +5,12 @@ variable "domain_name" {
 }
 
 variable "enabled" {
-  default = 1
+  default     = 1
   description = "Like count, but for the whole module. 1 for True, 0 for False."
 }
 
 variable "subject_alternative_names" {
-  default = []
+  default     = []
   description = "A list of additional names to add to the certificate"
 }
 
@@ -26,17 +26,15 @@ variable "validation_cname_ttl" {
 
 output "cert_arn" {
   description = "ARN of the issued ACM certificate"
-  value = "${element(concat(aws_acm_certificate.main.*.arn, list("")), 0)}"
+  value       = element(concat(aws_acm_certificate.main.*.arn, [""]), 0)
 }
 
 output "finished_id" {
   description = "Reference this output in order to depend on validation being complete."
-  value = "${element(concat(aws_acm_certificate_validation.main.*.id, list("")), 0)}"
+  value       = element(concat(aws_acm_certificate_validation.main.*.id, [""]), 0)
 }
 
-
 # -- Resources --
-
 
 # Create the certificate with the specified SubjectAltNames
 resource "aws_acm_certificate" "main" {
@@ -45,7 +43,7 @@ resource "aws_acm_certificate" "main" {
   domain_name               = var.domain_name
   subject_alternative_names = var.subject_alternative_names
 
-  validation_method         = "DNS"
+  validation_method = "DNS"
 
   lifecycle {
     create_before_destroy = true
@@ -59,11 +57,19 @@ resource "aws_acm_certificate" "main" {
 
 # Create each validation CNAME
 resource "aws_route53_record" "validation-cnames" {
-  count   = (length(var.subject_alternative_names) + 1) * var.enabled
-  name    = aws_acm_certificate.main[0].domain_validation_options[count.index].resource_record_name
-  type    = aws_acm_certificate.main[0].domain_validation_options[count.index].resource_record_type
+  count   = length(var.subject_alternative_names) + 1 * var.enabled
+  name    = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_name"]
+  type    = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_type"]
   zone_id = var.validation_zone_id
-  records = [aws_acm_certificate.main[0].domain_validation_options[count.index].resource_record_value]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  records = [aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_value"]]
   ttl     = var.validation_cname_ttl
 }
 
@@ -72,7 +78,8 @@ resource "aws_route53_record" "validation-cnames" {
 resource "aws_acm_certificate_validation" "main" {
   count = var.enabled
 
-  certificate_arn = aws_acm_certificate.main[count.index].arn
+  certificate_arn = aws_acm_certificate.main[0].arn
 
-  validation_record_fqdns = aws_route53_record.validation-cnames[*].fqdn
+  validation_record_fqdns = aws_route53_record.validation-cnames.*.fqdn
 }
+

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -57,19 +57,12 @@ resource "aws_acm_certificate" "main" {
 
 # Create each validation CNAME
 resource "aws_route53_record" "validation-cnames" {
-  count   = length(var.subject_alternative_names) + 1 * var.enabled
+  count = length(var.subject_alternative_names) + 1 * var.enabled
+
   name    = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_name"]
   type    = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_type"]
   zone_id = var.validation_zone_id
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  records = aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_value"]
+  records = [aws_acm_certificate.main.0.domain_validation_options[count.index]["resource_record_value"]]
   ttl     = var.validation_cname_ttl
 }
 

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -53,7 +53,7 @@ resource "aws_acm_certificate" "main" {
     # TODO: this is a workaround for an AWS API / Terraform AWS provider bug
     # https://github.com/terraform-providers/terraform-provider-aws/issues/8531
     # https://github.com/18F/identity-devops/issues/1469
-    ignore_changes = ["subject_alternative_names"]
+    ignore_changes = [subject_alternative_names]
   }
 }
 

--- a/acm_certificate/versions.tf
+++ b/acm_certificate/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/acm_certificate/versions.tf
+++ b/acm_certificate/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/asg_lifecycle_notifications/main.tf
+++ b/asg_lifecycle_notifications/main.tf
@@ -40,20 +40,20 @@ locals {
 }
 
 resource "aws_autoscaling_lifecycle_hook" "provision-private" {
-  count                  = "${local.private_hook_count}"
+  count                  = local.private_hook_count
   name                   = "${var.lifecycle_name_prefix}-private"
-  autoscaling_group_name = "${var.asg_name}"
+  autoscaling_group_name = var.asg_name
   default_result         = "ABANDON"
-  heartbeat_timeout      = "${var.private_heartbeat_timeout}"
+  heartbeat_timeout      = var.private_heartbeat_timeout
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
 }
 
 resource "aws_autoscaling_lifecycle_hook" "provision-main" {
-  count                  = "${local.main_hook_count}"
+  count                  = local.main_hook_count
   name                   = "${var.lifecycle_name_prefix}-main"
-  autoscaling_group_name = "${var.asg_name}"
+  autoscaling_group_name = var.asg_name
   default_result         = "ABANDON"
-  heartbeat_timeout      = "${var.main_heartbeat_timeout}"
+  heartbeat_timeout      = var.main_heartbeat_timeout
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
 }
 

--- a/asg_lifecycle_notifications/main.tf
+++ b/asg_lifecycle_notifications/main.tf
@@ -16,6 +16,7 @@ variable "lifecycle_name_prefix" {
   default     = "provision"
 }
 
+# TODO: change _enabled vars from int to bool
 variable "main_hook_enabled" {
   description = "Whether to create the $prefix-main lifecycle hook"
   default     = 1
@@ -62,12 +63,9 @@ resource "aws_autoscaling_lifecycle_hook" "provision-main" {
 }
 
 output "lifecycle_hook_names" {
-  value = [
-    concat(
-      aws_autoscaling_lifecycle_hook.provision-private.*.name,
-      aws_autoscaling_lifecycle_hook.provision-main.*.name,
-      [""],
-    ),
-  ]
+  value = concat(
+    aws_autoscaling_lifecycle_hook.provision-private.*.name,
+    aws_autoscaling_lifecycle_hook.provision-main.*.name
+  )
 }
 

--- a/asg_lifecycle_notifications/main.tf
+++ b/asg_lifecycle_notifications/main.tf
@@ -3,44 +3,47 @@
 # and provision-private.
 
 variable "asg_name" {
-	description = "Name of the auto scaling group that we're adding lifecycle hooks to."
+  description = "Name of the auto scaling group that we're adding lifecycle hooks to."
 }
 
 variable "enabled" {
   description = "Whether to enable the lifecycle hooks. This is a hack around terraform not supporting count for modules."
-  default = 1
+  default     = 1
 }
 
 variable "lifecycle_name_prefix" {
   description = "Prefix for the lifecycle hook names"
-  default = "provision"
+  default     = "provision"
 }
 
 variable "main_hook_enabled" {
   description = "Whether to create the $prefix-main lifecycle hook"
-  default = 1
+  default     = 1
 }
+
 variable "private_hook_enabled" {
   description = "Whether to create the $prefix-private lifecycle hook"
-  default = 1
+  default     = 1
 }
 
 variable "main_heartbeat_timeout" {
   description = "How long to wait before the main lifecycle hook times out"
-  default = 1800 # 30 minutes
+  default     = 1800 # 30 minutes
 }
+
 variable "private_heartbeat_timeout" {
   description = "How long to wait before the private lifecycle hook times out"
-  default = 900 # 15 minutes
+  default     = 900 # 15 minutes
 }
 
 locals {
-  main_hook_count = "${var.enabled * var.main_hook_enabled}"
-  private_hook_count = "${var.enabled * var.private_hook_enabled}"
+  main_hook_count    = var.enabled * var.main_hook_enabled
+  private_hook_count = var.enabled * var.private_hook_enabled
 }
 
 resource "aws_autoscaling_lifecycle_hook" "provision-private" {
-  count                  = local.private_hook_count
+  count = local.private_hook_count
+
   name                   = "${var.lifecycle_name_prefix}-private"
   autoscaling_group_name = var.asg_name
   default_result         = "ABANDON"
@@ -49,7 +52,8 @@ resource "aws_autoscaling_lifecycle_hook" "provision-private" {
 }
 
 resource "aws_autoscaling_lifecycle_hook" "provision-main" {
-  count                  = local.main_hook_count
+  count = local.main_hook_count
+
   name                   = "${var.lifecycle_name_prefix}-main"
   autoscaling_group_name = var.asg_name
   default_result         = "ABANDON"
@@ -58,9 +62,12 @@ resource "aws_autoscaling_lifecycle_hook" "provision-main" {
 }
 
 output "lifecycle_hook_names" {
-  value = ["${concat(
-    aws_autoscaling_lifecycle_hook.provision-private.*.name,
-    aws_autoscaling_lifecycle_hook.provision-main.*.name,
-    list("")
-  )}"]
+  value = [
+    concat(
+      aws_autoscaling_lifecycle_hook.provision-private.*.name,
+      aws_autoscaling_lifecycle_hook.provision-main.*.name,
+      [""],
+    ),
+  ]
 }
+

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -1,53 +1,52 @@
 # Remove this variable when modules support count
 # https://github.com/hashicorp/terraform/issues/953
 variable "enabled" {
-    default = 1
-    description = "Whether this module is enabled (hack around modules not supporting count)"
+  default     = 1
+  description = "Whether this module is enabled (hack around modules not supporting count)"
 }
 
 variable "asg_name" {
-    description = "Name of the auto scaling group to recycle"
+  description = "Name of the auto scaling group to recycle"
 }
 
 variable "normal_desired_capacity" {
-    description = ""
+  description = ""
 }
 
 variable "max_size" {
-    # in TF 0.10 you can leave this as the default
-    default = -1
+  default = -1
 }
 
 variable "min_size" {
-    # in TF 0.10 you can leave this as the default
-    default = -1
+  default = -1
 }
 
 variable "spinup_mult_factor" {
-    default = 2
-    description = "Multiple of normal_desired_capacity to spin up"
+  default     = 2
+  description = "Multiple of normal_desired_capacity to spin up"
 }
 
 variable "spinup_recurrence" {
-    default = ""
-    description = "Spinup times in cron format, sets aws_autoscaling_schedule.spinup.recurrence"
+  default     = ""
+  description = "Spinup times in cron format, sets aws_autoscaling_schedule.spinup.recurrence"
 }
+
 variable "spindown_recurrence" {
-    default = ""
-    description = "Spindown times in cron format, sets aws_autoscaling_schedule.spindown.recurrence"
+  default     = ""
+  description = "Spindown times in cron format, sets aws_autoscaling_schedule.spindown.recurrence"
 }
 
 variable "use_daily_business_hours_schedule" {
-    default = 0
-    description = "If set to 1, recycle once per business day rather than the every-six-hour default"
+  default     = 0
+  description = "If set to 1, recycle once per business day rather than the every-six-hour default"
 }
 
 # This block defines the actual default spinup/spindown schedule.
 # If use_daily_business_hours_schedule is enabled, from Mon-Fri spin up at 1700
 # UTC and spin down at 1800 UTC. Otherwise recycle every 6 hours every day by default.
 locals {
-    default_spinup_recurrence   = "${var.use_daily_business_hours_schedule == 1 ? "0 17 * * 1-5" : "0 5,11,17,23 * * *"}"
-    default_spindown_recurrence = "${var.use_daily_business_hours_schedule == 1 ? "0 18 * * 1-5" : "0 6,12,18,0 * * *"}"
+  default_spinup_recurrence   = var.use_daily_business_hours_schedule == 1 ? "0 17 * * 1-5" : "0 5,11,17,23 * * *"
+  default_spindown_recurrence = var.use_daily_business_hours_schedule == 1 ? "0 18 * * 1-5" : "0 6,12,18,0 * * *"
 }
 
 # Default schedule unless spinup_recurrence / spindown_recurrence are overridden:
@@ -74,24 +73,25 @@ locals {
 # Spin down at 5a, 11a, 5p, 11p PDT
 
 resource "aws_autoscaling_schedule" "spinup" {
-    count = var.enabled
+  count = var.enabled
 
-    scheduled_action_name  = "auto-recycle.spinup"
-    min_size               = var.min_size
-    max_size               = var.max_size
-    desired_capacity       = var.normal_desired_capacity * var.spinup_mult_factor
-    recurrence             = var.spinup_recurrence != "" ? var.spinup_recurrence : local.default_spinup_recurrence
-    autoscaling_group_name = var.asg_name
+  scheduled_action_name  = "auto-recycle.spinup"
+  min_size               = var.min_size
+  max_size               = var.max_size
+  desired_capacity       = var.normal_desired_capacity * var.spinup_mult_factor
+  recurrence             = var.spinup_recurrence != "" ? var.spinup_recurrence : local.default_spinup_recurrence
+  autoscaling_group_name = var.asg_name
 }
 
 resource "aws_autoscaling_schedule" "spindown" {
-    count = var.enabled
+  count = var.enabled
 
-    scheduled_action_name  = "auto-recycle.spindown"
-    min_size               = var.min_size
-    max_size               = var.max_size
-    desired_capacity       = var.normal_desired_capacity
-    recurrence             = var.spindown_recurrence != "" ? var.spindown_recurrence : local.default_spindown_recurrence
+  scheduled_action_name = "auto-recycle.spindown"
+  min_size              = var.min_size
+  max_size              = var.max_size
+  desired_capacity      = var.normal_desired_capacity
+  recurrence            = var.spindown_recurrence != "" ? var.spindown_recurrence : local.default_spindown_recurrence
 
-    autoscaling_group_name = var.asg_name
+  autoscaling_group_name = var.asg_name
 }
+

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -74,24 +74,24 @@ locals {
 # Spin down at 5a, 11a, 5p, 11p PDT
 
 resource "aws_autoscaling_schedule" "spinup" {
-    count = "${var.enabled}"
+    count = var.enabled
 
     scheduled_action_name  = "auto-recycle.spinup"
-    min_size               = "${var.min_size}"
-    max_size               = "${var.max_size}"
-    desired_capacity       = "${var.normal_desired_capacity * var.spinup_mult_factor}"
-    recurrence             = "${var.spinup_recurrence != "" ? var.spinup_recurrence : local.default_spinup_recurrence}"
-    autoscaling_group_name = "${var.asg_name}"
+    min_size               = var.min_size
+    max_size               = var.max_size
+    desired_capacity       = var.normal_desired_capacity * var.spinup_mult_factor
+    recurrence             = var.spinup_recurrence != "" ? var.spinup_recurrence : local.default_spinup_recurrence
+    autoscaling_group_name = var.asg_name
 }
 
 resource "aws_autoscaling_schedule" "spindown" {
-    count = "${var.enabled}"
+    count = var.enabled
 
     scheduled_action_name  = "auto-recycle.spindown"
-    min_size               = "${var.min_size}"
-    max_size               = "${var.max_size}"
-    desired_capacity       = "${var.normal_desired_capacity}"
-    recurrence             = "${var.spindown_recurrence != "" ? var.spindown_recurrence : local.default_spindown_recurrence}"
+    min_size               = var.min_size
+    max_size               = var.max_size
+    desired_capacity       = var.normal_desired_capacity
+    recurrence             = var.spindown_recurrence != "" ? var.spindown_recurrence : local.default_spindown_recurrence
 
-    autoscaling_group_name = "${var.asg_name}"
+    autoscaling_group_name = var.asg_name
 }

--- a/cloudwatch_dashboard_alb/main.tf
+++ b/cloudwatch_dashboard_alb/main.tf
@@ -53,8 +53,8 @@ output "dashboard_arn" {
 }
 
 resource "aws_cloudwatch_dashboard" "alb" {
-    count = "${var.enabled}"
-    dashboard_name = "${var.dashboard_name}"
+    count = var.enabled
+    dashboard_name = var.dashboard_name
     dashboard_body = <<EOF
 {
     "widgets": [

--- a/cloudwatch_dashboard_alb/main.tf
+++ b/cloudwatch_dashboard_alb/main.tf
@@ -1,61 +1,67 @@
 # main ALB dashboard
 
 variable "enabled" {
-    default = 1
+  default = 1
 }
 
 variable "dashboard_name" {
-    description = "Human-visible name of the dashboard"
+  description = "Human-visible name of the dashboard"
 }
 
 variable "alb_arn_suffix" {
-    description = "ARN suffix of the ALB"
+  description = "ARN suffix of the ALB"
 }
 
 variable "target_group_label" {
-    description = "Human label to explain what the target group servers are"
+  description = "Human label to explain what the target group servers are"
 }
 
 variable "target_group_arn_suffix" {
-    description = "ARN suffix of the target group, used for displaying response time"
+  description = "ARN suffix of the target group, used for displaying response time"
 }
 
 variable "asg_name" {
-    description = "Name of the ASG behind the ALB. Used for displaying CPU usage"
+  description = "Name of the ASG behind the ALB. Used for displaying CPU usage"
 }
 
 variable "vertical_annotations" {
-    description = "Raw JSON array of vertical annotations to add to all widgets"
-    default = "[]"
+  description = "Raw JSON array of vertical annotations to add to all widgets"
+  default     = "[]"
 }
 
 variable "region" {
-    description = "AWS region"
-    default = "us-west-2"
+  description = "AWS region"
+  default     = "us-west-2"
 }
 
 variable "response_time_warning_threshold" {
-    description = "Horizontal annotation for warning on response time graph"
-    default = 1
+  description = "Horizontal annotation for warning on response time graph"
+  default     = 1
 }
+
 variable "error_rate_warning_threshold" {
-    description = "Horizontal annotation for warning on error time graph"
-    default = 1
+  description = "Horizontal annotation for warning on error time graph"
+  default     = 1
 }
+
 variable "error_rate_error_threshold" {
-    description = "Horizontal annotation for error on error time graph"
-    default = 5
+  description = "Horizontal annotation for error on error time graph"
+  default     = 5
 }
 
 output "dashboard_arn" {
-    # This hack can go away in TF 0.12
-    value = "${element(concat(aws_cloudwatch_dashboard.alb.*.dashboard_arn, list("")), 0)}"
+  # This hack can go away in TF 0.12
+  value = element(
+    concat(aws_cloudwatch_dashboard.alb.*.dashboard_arn, [""]),
+    0,
+  )
 }
 
 resource "aws_cloudwatch_dashboard" "alb" {
-    count = var.enabled
-    dashboard_name = var.dashboard_name
-    dashboard_body = <<EOF
+  count = var.enabled
+
+  dashboard_name = var.dashboard_name
+  dashboard_body = <<EOF
 {
     "widgets": [
         {
@@ -291,4 +297,6 @@ resource "aws_cloudwatch_dashboard" "alb" {
     ]
 }
 EOF
+
 }
+

--- a/cloudwatch_dashboard_alb/main.tf
+++ b/cloudwatch_dashboard_alb/main.tf
@@ -1,9 +1,5 @@
 # main ALB dashboard
 
-variable "enabled" {
-  default = 1
-}
-
 variable "dashboard_name" {
   description = "Human-visible name of the dashboard"
 }
@@ -50,7 +46,7 @@ variable "error_rate_error_threshold" {
 }
 
 output "dashboard_arn" {
-  # This hack can go away in TF 0.12
+  # TODO: use a conditional to replace this after main TF12 rollout
   value = element(
     concat(aws_cloudwatch_dashboard.alb.*.dashboard_arn, [""]),
     0,
@@ -58,8 +54,6 @@ output "dashboard_arn" {
 }
 
 resource "aws_cloudwatch_dashboard" "alb" {
-  count = var.enabled
-
   dashboard_name = var.dashboard_name
   dashboard_body = <<EOF
 {

--- a/cloudwatch_dashboard_rds/main.tf
+++ b/cloudwatch_dashboard_rds/main.tf
@@ -1,37 +1,40 @@
 # main RDS dashboard
 
 variable "enabled" {
-    default = 1
+  default = 1
 }
 
 variable "dashboard_name" {
-    description = "Human-visible name of the dashboard"
+  description = "Human-visible name of the dashboard"
 }
 
 variable "region" {
-    description = "AWS Region"
+  description = "AWS Region"
 }
 
 variable "db_instance_identifier" {
-    description = "DB Instance Identifier of the RDS Instance"
+  description = "DB Instance Identifier of the RDS Instance"
 }
 
 variable "iops" {
-    description = "IOPS quota for the instance, if nonzero will be used to create a horizontal annotation on the R/W IOPS widget"
-    default = 0
+  description = "IOPS quota for the instance, if nonzero will be used to create a horizontal annotation on the R/W IOPS widget"
+  default     = 0
 }
 
 variable "vertical_annotations" {
-    description = "Raw JSON array of vertical annotations to add to all widgets"
-    default = "[]"
+  description = "Raw JSON array of vertical annotations to add to all widgets"
+  default     = "[]"
 }
 
 output "dashboard_arn" {
-    value = "${element(concat(aws_cloudwatch_dashboard.main.*.dashboard_arn, list("")), 0)}"
+  value = element(
+    concat(aws_cloudwatch_dashboard.main.*.dashboard_arn, [""]),
+    0,
+  )
 }
 
 locals {
-    iops_annotation_value = <<EOM
+  iops_annotation_value = <<EOM
 {
     "color": "#d62728",
     "label": "IOPS Quota",
@@ -39,13 +42,14 @@ locals {
 }
 EOM
 
-    iops_horizontal_annotations = "${var.iops > 0 ? "[${local.iops_annotation_value}]" : "[]"}"
+  iops_horizontal_annotations = var.iops > 0 ? "[${local.iops_annotation_value}]" : "[]"
 }
 
 resource "aws_cloudwatch_dashboard" "main" {
-    count = var.enabled
-    dashboard_name = var.dashboard_name
-    dashboard_body = <<EOF
+  count = var.enabled
+  
+  dashboard_name = var.dashboard_name
+  dashboard_body = <<EOF
 {
     "widgets": [
         {
@@ -279,4 +283,6 @@ resource "aws_cloudwatch_dashboard" "main" {
     ]
 }
 EOF
+
 }
+

--- a/cloudwatch_dashboard_rds/main.tf
+++ b/cloudwatch_dashboard_rds/main.tf
@@ -43,8 +43,8 @@ EOM
 }
 
 resource "aws_cloudwatch_dashboard" "main" {
-    count = "${var.enabled}"
-    dashboard_name = "${var.dashboard_name}"
+    count = var.enabled
+    dashboard_name = var.dashboard_name
     dashboard_body = <<EOF
 {
     "widgets": [

--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -10,7 +10,7 @@ data "aws_caller_identity" "current" {}
 # For the PR when ELB access logs were added in terraform to see an example of
 # the supported test cases for this ELB to S3 logging configuration.
 variable "elb_account_ids" {
-    type = "map"
+    type = map
     description = "Mapping of region to ELB account ID"
     default = {
         us-east-1 = "127311923021"
@@ -35,7 +35,7 @@ variable "elb_account_ids" {
 resource "aws_s3_bucket" "logs" {
   bucket = "${var.bucket_name_prefix}.elb-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
   acl    = "log-delivery-write"
-  force_destroy = "${var.force_destroy}"
+  force_destroy = var.force_destroy
 
   # Allow the ELB account in the current region to put objects.
   policy = <<EOF
@@ -56,7 +56,7 @@ resource "aws_s3_bucket" "logs" {
 }
 EOF
 
-  tags {
+  tags = {
     Environment = "All"
   }
 
@@ -83,36 +83,36 @@ EOF
 
   lifecycle_rule {
     id = "log_aging_ia"
-    enabled = "${var.lifecycle_days_standard_ia > 0 ? true : false}"
+    enabled = var.lifecycle_days_standard_ia > 0 ? true : false
 
     prefix  = "/"
 
     transition {
-      days = "${var.lifecycle_days_standard_ia}"
+      days = var.lifecycle_days_standard_ia
       storage_class = "STANDARD_IA"
     }
   }
 
   lifecycle_rule {
     id = "log_aging_glacier"
-    enabled = "${var.lifecycle_days_glacier > 0 ? true : false}"
+    enabled = var.lifecycle_days_glacier > 0 ? true : false
 
     prefix  = "/"
 
     transition {
-      days = "${var.lifecycle_days_glacier}"
+      days = var.lifecycle_days_glacier
       storage_class = "GLACIER"
     }
   }
 
   lifecycle_rule {
     id = "log_aging_expire"
-    enabled = "${var.lifecycle_days_expire > 0 ? true : false}"
+    enabled = var.lifecycle_days_expire > 0 ? true : false
 
     prefix  = "/"
 
     expiration {
-      days = "${var.lifecycle_days_expire}"
+      days = var.lifecycle_days_expire
     }
   }
 }

--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -1,4 +1,5 @@
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 # To give ELBs the ability to upload logs to an S3 bucket, we need to create a
 # policy that gives permission to a magical AWS account ID to upload logs to our
@@ -10,31 +11,31 @@ data "aws_caller_identity" "current" {}
 # For the PR when ELB access logs were added in terraform to see an example of
 # the supported test cases for this ELB to S3 logging configuration.
 variable "elb_account_ids" {
-    type = map
-    description = "Mapping of region to ELB account ID"
-    default = {
-        us-east-1 = "127311923021"
-        us-east-2 = "033677994240"
-        us-west-1 = "027434742980"
-        us-west-2 = "797873946194"
-        ca-central-1 = "985666609251"
-        eu-west-1 = "156460612806"
-        eu-central-1 = "054676820928"
-        eu-west-2 = "652711504416"
-        ap-northeast-1 = "582318560864"
-        ap-northeast-2 = "600734575887"
-        ap-southeast-1 = "114774131450"
-        ap-southeast-2 = "783225319266"
-        ap-south-1 = "718504428378"
-        sa-east-1 = "507241528517"
-        us-gov-west-1 = "048591011584"
-        cn-north-1 = "638102146993"
-    }
+  type        = map(string)
+  description = "Mapping of region to ELB account ID"
+  default = {
+    us-east-1      = "127311923021"
+    us-east-2      = "033677994240"
+    us-west-1      = "027434742980"
+    us-west-2      = "797873946194"
+    ca-central-1   = "985666609251"
+    eu-west-1      = "156460612806"
+    eu-central-1   = "054676820928"
+    eu-west-2      = "652711504416"
+    ap-northeast-1 = "582318560864"
+    ap-northeast-2 = "600734575887"
+    ap-southeast-1 = "114774131450"
+    ap-southeast-2 = "783225319266"
+    ap-south-1     = "718504428378"
+    sa-east-1      = "507241528517"
+    us-gov-west-1  = "048591011584"
+    cn-north-1     = "638102146993"
+  }
 }
 
 resource "aws_s3_bucket" "logs" {
-  bucket = "${var.bucket_name_prefix}.elb-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
-  acl    = "log-delivery-write"
+  bucket        = "${var.bucket_name_prefix}.elb-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
+  acl           = "log-delivery-write"
   force_destroy = var.force_destroy
 
   # Allow the ELB account in the current region to put objects.
@@ -47,72 +48,81 @@ resource "aws_s3_bucket" "logs" {
       "Sid": "Stmt1503676946489",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::${lookup(var.elb_account_ids, var.region)}:root"
+        "AWS": "arn:aws:iam::${var.elb_account_ids[var.region]}:root"
       },
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::${var.bucket_name_prefix}.elb-logs.${data.aws_caller_identity.current.account_id}-${var.region}/${var.use_prefix_for_permissions ? join("/",list(var.log_prefix,"AWSLogs",data.aws_caller_identity.current.account_id,"*")) : "*"}"
+      "Resource": "arn:aws:s3:::${var.bucket_name_prefix}.elb-logs.${data.aws_caller_identity.current.account_id}-${var.region}/${var.use_prefix_for_permissions ? join(
+  "/",
+  [
+    var.log_prefix,
+    "AWSLogs",
+    data.aws_caller_identity.current.account_id,
+    "*",
+  ],
+) : "*"}"
     }
   ]
 }
 EOF
 
-  tags = {
-    Environment = "All"
-  }
 
-  # In theory we should only put one copy of every file, so I don't think this
-  # will increase space, just give us history in case we accidentally
-  # delete/modify something.
-  versioning {
-    enabled = true
-  }
+tags = {
+  Environment = "All"
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
-      }
-    }
-  }
+# In theory we should only put one copy of every file, so I don't think this
+# will increase space, just give us history in case we accidentally
+# delete/modify something.
+versioning {
+  enabled = true
+}
 
-
-  # Lifecycle rules: configure a sliding window for moving logs from standard
-  # storage to standard Infrequent Access, then to glacier, then deleting them.
-  # The rules will only be enabled if the lifecycle day threshold is set to a
-  # positive number.
-
-  lifecycle_rule {
-    id = "log_aging_ia"
-    enabled = var.lifecycle_days_standard_ia > 0 ? true : false
-
-    prefix  = "/"
-
-    transition {
-      days = var.lifecycle_days_standard_ia
-      storage_class = "STANDARD_IA"
-    }
-  }
-
-  lifecycle_rule {
-    id = "log_aging_glacier"
-    enabled = var.lifecycle_days_glacier > 0 ? true : false
-
-    prefix  = "/"
-
-    transition {
-      days = var.lifecycle_days_glacier
-      storage_class = "GLACIER"
-    }
-  }
-
-  lifecycle_rule {
-    id = "log_aging_expire"
-    enabled = var.lifecycle_days_expire > 0 ? true : false
-
-    prefix  = "/"
-
-    expiration {
-      days = var.lifecycle_days_expire
+server_side_encryption_configuration {
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
     }
   }
 }
+
+# Lifecycle rules: configure a sliding window for moving logs from standard
+# storage to standard Infrequent Access, then to glacier, then deleting them.
+# The rules will only be enabled if the lifecycle day threshold is set to a
+# positive number.
+
+lifecycle_rule {
+  id      = "log_aging_ia"
+  enabled = var.lifecycle_days_standard_ia > 0 ? true : false
+
+  prefix = "/"
+
+  transition {
+    days          = var.lifecycle_days_standard_ia
+    storage_class = "STANDARD_IA"
+  }
+}
+
+lifecycle_rule {
+  id      = "log_aging_glacier"
+  enabled = var.lifecycle_days_glacier > 0 ? true : false
+
+  prefix = "/"
+
+  transition {
+    days          = var.lifecycle_days_glacier
+    storage_class = "GLACIER"
+  }
+}
+
+lifecycle_rule {
+  id      = "log_aging_expire"
+  enabled = var.lifecycle_days_expire > 0 ? true : false
+
+  prefix = "/"
+
+  expiration {
+    days = var.lifecycle_days_expire
+  }
+}
+}
+

--- a/elb_access_logs_bucket/outputs.tf
+++ b/elb_access_logs_bucket/outputs.tf
@@ -1,4 +1,5 @@
 output "bucket_name" {
-    description = "Name of the s3 logs bucket that was created"
-    value = "${aws_s3_bucket.logs.id}"
+  description = "Name of the s3 logs bucket that was created"
+  value       = aws_s3_bucket.logs.id
 }
+

--- a/elb_access_logs_bucket/variables.tf
+++ b/elb_access_logs_bucket/variables.tf
@@ -1,41 +1,41 @@
 variable "region" {
-    description = "Region to create the secrets bucket in"
-    default = "us-west-2"
+  description = "Region to create the secrets bucket in"
+  default     = "us-west-2"
 }
 
 variable "bucket_name_prefix" {
-    description = "Base name for the secrets bucket to create"
+  description = "Base name for the secrets bucket to create"
 }
 
 variable "log_prefix" {
-    description = "Prefix inside the bucket where access logs will go"
-    default = "logs"
+  description = "Prefix inside the bucket where access logs will go"
+  default     = "logs"
 }
 
 # This is optional to support the use case where multiple loadbalancers use the
 # same S3 bucket with different log prefixes.
 variable "use_prefix_for_permissions" {
-    description = "Scope load balancer permissions by log_prefix"
-    default = false
+  description = "Scope load balancer permissions by log_prefix"
+  default     = false
 }
 
 variable "force_destroy" {
-    default = false
-    description = "Allow destroy even if bucket contains objects"
+  default     = false
+  description = "Allow destroy even if bucket contains objects"
 }
 
-
 variable "lifecycle_days_standard_ia" {
-    description = "Number of days after object creation to move logs to Standard Infrequent Access. Set to 0 to disable."
-    default = 60
+  description = "Number of days after object creation to move logs to Standard Infrequent Access. Set to 0 to disable."
+  default     = 60
 }
 
 variable "lifecycle_days_glacier" {
-    description = "Number of days after object creation to move logs to Glacier. Set to 0 to disable."
-    default = 365
+  description = "Number of days after object creation to move logs to Glacier. Set to 0 to disable."
+  default     = 365
 }
 
 variable "lifecycle_days_expire" {
-    description = "Number of days after object creation to delete logs. Set to 0 to disable."
-    default = 0
+  description = "Number of days after object creation to delete logs. Set to 0 to disable."
+  default     = 0
 }
+

--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -26,20 +26,20 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
     alarm_description = "HTTP 5XX errors served by the ELB without the IDP (Managed by Terraform)"
     namespace = "AWS/ApplicationELB"
     metric_name = "HTTPCode_ELB_5XX_Count"
-    dimensions {
+    dimensions = {
       LoadBalancer = "${var.load_balancer_id}"
     }
 
     statistic = "Sum"
     comparison_operator = "GreaterThanOrEqualToThreshold"
-    threshold = "${var.elb_threshold}"
+    threshold = var.elb_threshold
     period = 60
     datapoints_to_alarm = 1
     evaluation_periods = 1
 
     treat_missing_data = "missing"
 
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = var.alarm_actions
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
@@ -47,17 +47,17 @@ resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
     alarm_description = "HTTP 5XX errors served by IDP (Managed by Terraform)"
     namespace = "AWS/ApplicationELB"
     metric_name = "HTTPCode_Target_5XX_Count"
-    dimensions {
+    dimensions = {
       LoadBalancer = "${var.load_balancer_id}"
     }
 
     statistic = "Sum"
     comparison_operator = "GreaterThanOrEqualToThreshold"
-    threshold = "${var.target_threshold}"
+    threshold = var.target_threshold
     period = 300
     evaluation_periods = 1
 
     treat_missing_data = "notBreaching"
 
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = var.alarm_actions
 }

--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -7,7 +7,7 @@ variable "load_balancer_id" {
 }
 
 variable "alarm_actions" {
-    type = "list"
+    type = list
     description = "A list of ARNs to notify when the ELB alarms fire"
 }
 

--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -1,63 +1,64 @@
 variable "env_name" {
-    description = "Environment name, for prefixing the generated metric names"
+  description = "Environment name, for prefixing the generated metric names"
 }
 
 variable "load_balancer_id" {
-    description = "ID of the IDP load balancer"
+  description = "ID of the IDP load balancer"
 }
 
 variable "alarm_actions" {
-    type = list
-    description = "A list of ARNs to notify when the ELB alarms fire"
+  type        = list(string)
+  description = "A list of ARNs to notify when the ELB alarms fire"
 }
 
 variable "elb_threshold" {
-    description = "Number of errors to trigger ELB 5xx alarm"
-    default = 30
+  description = "Number of errors to trigger ELB 5xx alarm"
+  default     = 30
 }
 
 variable "target_threshold" {
-    description = "Number of errors to trigger target 5xx alarm"
-    default = 150
+  description = "Number of errors to trigger target 5xx alarm"
+  default     = 150
 }
 
 resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
-    alarm_name = "${var.env_name} IDP ELB HTTP 5XX"
-    alarm_description = "HTTP 5XX errors served by the ELB without the IDP (Managed by Terraform)"
-    namespace = "AWS/ApplicationELB"
-    metric_name = "HTTPCode_ELB_5XX_Count"
-    dimensions = {
-      LoadBalancer = "${var.load_balancer_id}"
-    }
+  alarm_name        = "${var.env_name} IDP ELB HTTP 5XX"
+  alarm_description = "HTTP 5XX errors served by the ELB without the IDP (Managed by Terraform)"
+  namespace         = "AWS/ApplicationELB"
+  metric_name       = "HTTPCode_ELB_5XX_Count"
+  dimensions = {
+    LoadBalancer = var.load_balancer_id
+  }
 
-    statistic = "Sum"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    threshold = var.elb_threshold
-    period = 60
-    datapoints_to_alarm = 1
-    evaluation_periods = 1
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.elb_threshold
+  period              = 60
+  datapoints_to_alarm = 1
+  evaluation_periods  = 1
 
-    treat_missing_data = "missing"
+  treat_missing_data = "missing"
 
-    alarm_actions = var.alarm_actions
+  alarm_actions = var.alarm_actions
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
-    alarm_name = "${var.env_name} IDP Target HTTP 5XX"
-    alarm_description = "HTTP 5XX errors served by IDP (Managed by Terraform)"
-    namespace = "AWS/ApplicationELB"
-    metric_name = "HTTPCode_Target_5XX_Count"
-    dimensions = {
-      LoadBalancer = "${var.load_balancer_id}"
-    }
+  alarm_name        = "${var.env_name} IDP Target HTTP 5XX"
+  alarm_description = "HTTP 5XX errors served by IDP (Managed by Terraform)"
+  namespace         = "AWS/ApplicationELB"
+  metric_name       = "HTTPCode_Target_5XX_Count"
+  dimensions = {
+    LoadBalancer = var.load_balancer_id
+  }
 
-    statistic = "Sum"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    threshold = var.target_threshold
-    period = 300
-    evaluation_periods = 1
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.target_threshold
+  period              = 300
+  evaluation_periods  = 1
 
-    treat_missing_data = "notBreaching"
+  treat_missing_data = "notBreaching"
 
-    alarm_actions = var.alarm_actions
+  alarm_actions = var.alarm_actions
 }
+

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -1,10 +1,8 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_s3_bucket" "ct_log_bucket"
-{
-    bucket = "login-gov-cloudtrail-${data.aws_caller_identity.current.account_id}"
+data "aws_s3_bucket" "ct_log_bucket" {
+  bucket = "login-gov-cloudtrail-${data.aws_caller_identity.current.account_id}"
 }
-
 
 resource "null_resource" "key_found" {
   triggers = {
@@ -18,15 +16,13 @@ resource "null_resource" "kms_log_found" {
   }
 }
 
-data "aws_kms_key" "application"
-{
-    depends_on = ["null_resource.key_found"]
-    key_id = "alias/${var.env_name}-login-dot-gov-keymaker"
+data "aws_kms_key" "application" {
+  depends_on = ["null_resource.key_found"]
+  key_id = "alias/${var.env_name}-login-dot-gov-keymaker"
 }
 
-data "aws_s3_bucket" "lambda"
-{
-    bucket = "login-gov.lambda-functions.${data.aws_caller_identity.current.account_id}-${var.region}"
+data "aws_s3_bucket" "lambda" {
+  bucket = "login-gov.lambda-functions.${data.aws_caller_identity.current.account_id}-${var.region}"
 }
 
 locals {
@@ -53,8 +49,7 @@ resource "aws_kms_key" "kms_logging" {
 }
 
 # IAM policy for KMS access by CW Events and SNS
-data "aws_iam_policy_document" "kms"
-{
+data "aws_iam_policy_document" "kms" {
     statement {
         sid = "Enable IAM User Permissions"
         effect = "Allow"
@@ -393,7 +388,7 @@ resource "aws_kinesis_stream" "datastream" {
     name = "${var.env_name}-kms-app-events"
     shard_count = "${var.kinesis_shard_count}"
     retention_period = "${var.kinesis_retention_hours}"
-    encryption_type = "KMS",
+    encryption_type = "KMS"
     kms_key_id="alias/aws/kinesis"
 
     shard_level_metrics = [

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -17,7 +17,7 @@ resource "null_resource" "kms_log_found" {
 }
 
 data "aws_kms_key" "application" {
-  depends_on = ["null_resource.key_found"]
+  depends_on = [null_resource.key_found]
   key_id = "alias/${var.env_name}-login-dot-gov-keymaker"
 }
 
@@ -475,7 +475,7 @@ resource "aws_cloudwatch_log_destination_policy" "subscription" {
 # create subscription filter 
 # this filter will send the kms.log events to kinesis
 resource "aws_cloudwatch_log_subscription_filter" "kinesis" {
-    depends_on = ["null_resource.kms_log_found"]
+    depends_on = [null_resource.kms_log_found]
     count = var.kmslogging_service_enabled
     name = "${var.env_name}-kms-app-log"
     log_group_name = "${var.env_name}_/srv/idp/shared/log/kms.log"
@@ -681,7 +681,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
     s3_key = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
 
     lifecycle {
-        ignore_changes = ["s3_key", "last_modified"]
+        ignore_changes = [s3_key, last_modified]
     }
 
     function_name = local.ct_processor_lambda_name
@@ -859,7 +859,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
     s3_key = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
 
     lifecycle {
-        ignore_changes = ["s3_key", "last_modified"]
+        ignore_changes = [s3_key, last_modified]
     }
 
     function_name = local.cw_processor_lambda_name
@@ -990,7 +990,7 @@ resource "aws_lambda_function" "event_processor" {
     s3_key = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
 
     lifecycle {
-        ignore_changes = ["s3_key", "last_modified"]
+        ignore_changes = [s3_key, last_modified]
     }
 
     function_name = local.event_processor_lambda_name

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -709,7 +709,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 
   environment {
     variables = {
-      DEBUG               = var.kmslog_lambda_debug ? "1" : ""
+      DEBUG               = var.kmslog_lambda_debug == 1 ? "1" : ""
       LOG_LEVEL           = "0"
       CT_QUEUE_URL        = aws_sqs_queue.kms_ct_events.id
       RETENTION_DAYS      = var.dynamodb_retention_days
@@ -891,7 +891,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 
   environment {
     variables = {
-      DEBUG               = var.kmslog_lambda_debug ? "1" : ""
+      DEBUG               = var.kmslog_lambda_debug == 1 ? "1" : ""
       LOG_LEVEL           = "0"
       RETENTION_DAYS      = var.dynamodb_retention_days
       DDB_TABLE           = aws_dynamodb_table.kms_events.id
@@ -1027,7 +1027,7 @@ resource "aws_lambda_function" "event_processor" {
 
   environment {
     variables = {
-      DEBUG     = var.kmslog_lambda_debug ? "1" : ""
+      DEBUG     = var.kmslog_lambda_debug == 1 ? "1" : ""
       LOG_LEVEL = "0"
       ENV_NAME  = var.env_name
     }

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -1,4 +1,5 @@
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "aws_s3_bucket" "ct_log_bucket" {
   bucket = "login-gov-cloudtrail-${data.aws_caller_identity.current.account_id}"
@@ -18,7 +19,7 @@ resource "null_resource" "kms_log_found" {
 
 data "aws_kms_key" "application" {
   depends_on = [null_resource.key_found]
-  key_id = "alias/${var.env_name}-login-dot-gov-keymaker"
+  key_id     = "alias/${var.env_name}-login-dot-gov-keymaker"
 }
 
 data "aws_s3_bucket" "lambda" {
@@ -26,129 +27,130 @@ data "aws_s3_bucket" "lambda" {
 }
 
 locals {
-    kms_alias = "alias/${var.env_name}-kms-logging"
-    dynamodb_table_name = "${var.env_name}-kms-logging"
-    kinesis_stream_name = "${var.env_name}-kms-app-events"
-    decryption_event_rule_name = "${var.env_name}-decryption-events"
-    kmslog_event_rule_name = "${var.env_name}-unmatched-kmslog"
-    dashboard_name = "${var.env_name}-kms-logging"
-    ct_processor_lambda_name = "${var.env_name}-cloudtrail-kms"
-    cw_processor_lambda_name = "${var.env_name}-cloudwatch-kms"
-    event_processor_lambda_name = "${var.env_name}-kmslog-event-processor"
+  kms_alias                   = "alias/${var.env_name}-kms-logging"
+  dynamodb_table_name         = "${var.env_name}-kms-logging"
+  kinesis_stream_name         = "${var.env_name}-kms-app-events"
+  decryption_event_rule_name  = "${var.env_name}-decryption-events"
+  kmslog_event_rule_name      = "${var.env_name}-unmatched-kmslog"
+  dashboard_name              = "${var.env_name}-kms-logging"
+  ct_processor_lambda_name    = "${var.env_name}-cloudtrail-kms"
+  cw_processor_lambda_name    = "${var.env_name}-cloudwatch-kms"
+  event_processor_lambda_name = "${var.env_name}-kmslog-event-processor"
 }
 
 # create cmk for kms logging solution
 resource "aws_kms_key" "kms_logging" {
-    description = "KMS logging key"
-    enable_key_rotation = true
-    policy = data.aws_iam_policy_document.kms.json
-    tags = {
-       Name = "${var.env_name} KMS Logging Key"
-       environment = "${var.env_name}" 
-    }
+  description         = "KMS logging key"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.kms.json
+  tags = {
+    Name        = "${var.env_name} KMS Logging Key"
+    environment = var.env_name
+  }
 }
 
 # IAM policy for KMS access by CW Events and SNS
 data "aws_iam_policy_document" "kms" {
-    statement {
-        sid = "Enable IAM User Permissions"
-        effect = "Allow"
-        actions = [
-            "kms:*"
-        ]
-        resources = [
-            "*"
-        ]
-        principals {
-            type = "AWS"
-            identifiers = [
-                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-            ]
-        }
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      "*",
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
     }
+  }
 
-    statement {
-        sid = "Allow CloudWatch Events and SNS Access"
-        effect = "Allow"
-        actions = [
-            "kms:GenerateDataKey",
-            "kms:Decrypt"
-        ]
-        resources = [
-            "*"
-        ]
-        principals {
-            type = "Service"
-            identifiers = [
-                "events.amazonaws.com",
-                "sns.amazonaws.com"
-            ]
-        }
+  statement {
+    sid    = "Allow CloudWatch Events and SNS Access"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = [
+      "*",
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "sns.amazonaws.com",
+      ]
     }
+  }
 }
 
 resource "aws_kms_alias" "kms_logging" {
-    name = local.kms_alias
-    target_key_id = aws_kms_key.kms_logging.key_id
+  name          = local.kms_alias
+  target_key_id = aws_kms_key.kms_logging.key_id
 }
 
 # create dead letter queue for kms cloudtrail events
 resource "aws_sqs_queue" "dead_letter" {
-    name = "${var.env_name}-kms-dead-letter"
-    kms_master_key_id = aws_kms_key.kms_logging.arn
-    kms_data_key_reuse_period_seconds = 600
-    message_retention_seconds = 604800 # 7 days
-    tags = {
-        environment = "${var.env_name}"
-    }
+  name                              = "${var.env_name}-kms-dead-letter"
+  kms_master_key_id                 = aws_kms_key.kms_logging.arn
+  kms_data_key_reuse_period_seconds = 600
+  message_retention_seconds         = 604800 # 7 days
+  tags = {
+    environment = var.env_name
+  }
 }
 
 # queue for cloudtrail kms events
 resource "aws_sqs_queue" "kms_ct_events" {
-    name = "${var.env_name}-kms-ct-events"
-    delay_seconds = var.ct_queue_delay_seconds
-    max_message_size =  var.ct_queue_max_message_size
-    visibility_timeout_seconds = var.ct_queue_visibility_timeout_seconds
-    message_retention_seconds = var.ct_queue_message_retention_seconds
-    kms_master_key_id = aws_kms_key.kms_logging.arn
-    kms_data_key_reuse_period_seconds = 600 # number of seconds the kms key is cached
-    redrive_policy = <<POLICY
+  name                              = "${var.env_name}-kms-ct-events"
+  delay_seconds                     = var.ct_queue_delay_seconds
+  max_message_size                  = var.ct_queue_max_message_size
+  visibility_timeout_seconds        = var.ct_queue_visibility_timeout_seconds
+  message_retention_seconds         = var.ct_queue_message_retention_seconds
+  kms_master_key_id                 = aws_kms_key.kms_logging.arn
+  kms_data_key_reuse_period_seconds = 600 # number of seconds the kms key is cached
+  redrive_policy                    = <<POLICY
 {
     "deadLetterTargetArn": "${aws_sqs_queue.dead_letter.arn}",
     "maxReceiveCount": ${var.ct_queue_maxreceivecount}
 }
 POLICY
-tags = {
-        environment = "${var.env_name}"
-    }
+
+
+  tags = {
+    environment = var.env_name
+  }
 }
 
 resource "aws_sqs_queue_policy" "default" {
-    queue_url = aws_sqs_queue.kms_ct_events.id
-    policy = data.aws_iam_policy_document.sqs_kms_ct_events_policy.json
+  queue_url = aws_sqs_queue.kms_ct_events.id
+  policy    = data.aws_iam_policy_document.sqs_kms_ct_events_policy.json
 }
 
 # iam policy for sqs that allows cloudwatch events to 
 # deliver events to the queue
 data "aws_iam_policy_document" "sqs_kms_ct_events_policy" {
-    statement {
-        sid = "Allow CloudWatch Events"
-        effect = "Allow"
-        actions = ["sqs:SendMessage"]
-        principals {
-            type = "Service"
-            identifiers = ["events.amazonaws.com"]
-        }
-        resources = ["${aws_sqs_queue.kms_ct_events.arn}"]
-        condition {
-            test = "StringLike"
-            variable = "aws:SourceArn"
-            values = [
-                "arn:aws:events:${var.region}:${data.aws_caller_identity.current.account_id}:rule/${local.decryption_event_rule_name}"
-            ]
-
-        }
+  statement {
+    sid     = "Allow CloudWatch Events"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
     }
+    resources = [aws_sqs_queue.kms_ct_events.arn]
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:events:${var.region}:${data.aws_caller_identity.current.account_id}:rule/${local.decryption_event_rule_name}",
+      ]
+    }
+  }
 }
 
 # cloudwatch event rule to capture cloudtrail kms decryption events
@@ -158,11 +160,12 @@ data "aws_iam_policy_document" "sqs_kms_ct_events_policy" {
 # this filter also is only capturing events for a single 
 # kms key
 resource "aws_cloudwatch_event_rule" "decrypt" {
-    count = var.kmslogging_service_enabled
-    name = local.decryption_event_rule_name
-    description = "Capture decryption events"
+  count = var.kmslogging_service_enabled
+  
+  name        = local.decryption_event_rule_name
+  description = "Capture decryption events"
 
-    event_pattern = <<PATTERN
+  event_pattern = <<PATTERN
 {
     "source": [
         "aws.kms"
@@ -193,83 +196,88 @@ resource "aws_cloudwatch_event_rule" "decrypt" {
     }
 }
 PATTERN
+
 }
 
 # sets the receiver of the cloudwatch events
 # to the sqs queue
 resource "aws_cloudwatch_event_target" "sqs" {
-    count = var.kmslogging_service_enabled
-    rule = aws_cloudwatch_event_rule.decrypt[count.index].name
-    target_id = "${var.env_name}-sqs"
-    arn = aws_sqs_queue.kms_ct_events.arn
+  count = var.kmslogging_service_enabled
+  
+  rule      = aws_cloudwatch_event_rule.decrypt[0].name
+  target_id = "${var.env_name}-sqs"
+  arn       = aws_sqs_queue.kms_ct_events.arn
 }
 
 # event rule for custom events
 resource "aws_cloudwatch_event_rule" "unmatched" {
-    count = var.kmslogging_service_enabled
-    name = local.kmslog_event_rule_name
-    description = "Capture Unmatched KMS Log Events"
+  count = var.kmslogging_service_enabled
+  
+  name        = local.kmslog_event_rule_name
+  description = "Capture Unmatched KMS Log Events"
 
-    event_pattern = <<PATTERN
+  event_pattern = <<PATTERN
 {
     "source":["gov.login.app"],
     "detail": {"environment": ["${var.env_name}"]}
 }
 PATTERN
+
 }
 
 resource "aws_cloudwatch_event_target" "unmatched" {
-    count = var.kmslogging_service_enabled
-    rule = aws_cloudwatch_event_rule.unmatched[0].name
-    target_id = "${var.env_name}-slack"
-    arn = var.sns_topic_dead_letter_arn
+  count = var.kmslogging_service_enabled
+  
+  rule      = aws_cloudwatch_event_rule.unmatched[0].name
+  target_id = "${var.env_name}-slack"
+  arn       = var.sns_topic_dead_letter_arn
 }
 
 # dynamodb table for event correlation
 resource "aws_dynamodb_table" "kms_events" {
-    name = local.dynamodb_table_name
-    billing_mode = "PAY_PER_REQUEST"
-    hash_key = "UUID"
-    range_key = "Timestamp"
+  name         = local.dynamodb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "UUID"
+  range_key    = "Timestamp"
 
-    attribute {
-        name = "UUID"
-        type = "S"
-    }
+  attribute {
+    name = "UUID"
+    type = "S"
+  }
 
-    attribute {
-        name = "Timestamp"
-        type = "S"
-    }
+  attribute {
+    name = "Timestamp"
+    type = "S"
+  }
 
-    attribute {
-        name = "Correlated"
-        type = "S"
-    }
+  attribute {
+    name = "Correlated"
+    type = "S"
+  }
 
-    global_secondary_index {
-        name = "Correlated_Index"
-        hash_key = "UUID"
-        range_key = "Correlated"
-        projection_type = "KEYS_ONLY"
-    }
+  global_secondary_index {
+    name            = "Correlated_Index"
+    hash_key        = "UUID"
+    range_key       = "Correlated"
+    projection_type = "KEYS_ONLY"
+  }
 
-    ttl {
-        attribute_name = "TimeToExist"
-        enabled = true
-    }
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = true
+  }
 
-    point_in_time_recovery {
-        enabled = true
-    }
+  point_in_time_recovery {
+    enabled = true
+  }
 
-    server_side_encryption {
-        enabled = true
-    }
+  server_side_encryption {
+    enabled = true
+  }
 
   tags = {
-    Name = "${local.dynamodb_table_name}"
-    environment = "${var.env_name}"
+    Name        = local.dynamodb_table_name
+    environment = var.env_name
   }
 }
 
@@ -277,216 +285,217 @@ resource "aws_dynamodb_table" "kms_events" {
 # by the lambda that process the cloudtrail 
 # events
 resource "aws_sns_topic" "kms_logging_events" {
-    name = "${var.env_name}-kms-logging-events"
-    display_name = "KMS Events"
-    kms_master_key_id = local.kms_alias
+  name              = "${var.env_name}-kms-logging-events"
+  display_name      = "KMS Events"
+  kms_master_key_id = local.kms_alias
 }
 
 # queue to receive events from the logging events
 # sns topic for delivery of metrics to cloudwatch
 resource "aws_sqs_queue" "kms_cloudwatch_events" {
-    name = "${var.env_name}-kms-cw-events"
-    delay_seconds = 5
-    max_message_size = 2048
-    visibility_timeout_seconds = 120
-    message_retention_seconds = 345600 # 4 days
-    kms_master_key_id = aws_kms_key.kms_logging.arn
-    kms_data_key_reuse_period_seconds = 600
-    tags = {
-        environment = "${var.env_name}"
-    }
+  name                              = "${var.env_name}-kms-cw-events"
+  delay_seconds                     = 5
+  max_message_size                  = 2048
+  visibility_timeout_seconds        = 120
+  message_retention_seconds         = 345600 # 4 days
+  kms_master_key_id                 = aws_kms_key.kms_logging.arn
+  kms_data_key_reuse_period_seconds = 600
+  tags = {
+    environment = var.env_name
+  }
 }
 
 resource "aws_sqs_queue_policy" "kms_cloudwatch_events" {
-    queue_url = aws_sqs_queue.kms_cloudwatch_events.id
-    policy = data.aws_iam_policy_document.sqs_kms_cw_events_policy.json
+  queue_url = aws_sqs_queue.kms_cloudwatch_events.id
+  policy    = data.aws_iam_policy_document.sqs_kms_cw_events_policy.json
 }
 
 # policy for queue that receives events for cloudwatch metrics
 data "aws_iam_policy_document" "sqs_kms_cw_events_policy" {
-    statement {
-        sid = "Allow SQS"
-        effect = "Allow"
-        actions = ["sqs:SendMessage"]
-        principals {
-            type = "Service"
-            identifiers = [
-                "sns.amazonaws.com"
-            ]
-        }
-        resources = ["${aws_sqs_queue.kms_cloudwatch_events.arn}"]
-        condition {
-            test = "StringLike"
-            variable = "aws:SourceArn"
-            values = [
-                "${aws_sns_topic.kms_logging_events.arn}"
-            ]
-
-        }
+  statement {
+    sid     = "Allow SQS"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    principals {
+      type = "Service"
+      identifiers = [
+        "sns.amazonaws.com",
+      ]
     }
+    resources = [aws_sqs_queue.kms_cloudwatch_events.arn]
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values = [
+        aws_sns_topic.kms_logging_events.arn,
+      ]
+    }
+  }
 }
 
 # subscription for cloudwatch metrics queue to the sns topic
 resource "aws_sns_topic_subscription" "kms_events_sqs_cw_target" {
-    topic_arn = aws_sns_topic.kms_logging_events.arn
-    protocol  = "sqs"
-    endpoint  = aws_sqs_queue.kms_cloudwatch_events.arn
+  topic_arn = aws_sns_topic.kms_logging_events.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.kms_cloudwatch_events.arn
 }
 
 # queue to deliver metrics from cloudtrail lambda to
 # elasticsearch
 resource "aws_sqs_queue" "kms_elasticsearch_events" {
-    name = "${var.env_name}-kms-es-events"
-    delay_seconds = 5
-    max_message_size = 2048
-    visibility_timeout_seconds = 120
-    message_retention_seconds = 345600 # 4 days
-    kms_master_key_id = aws_kms_key.kms_logging.arn
-    kms_data_key_reuse_period_seconds = 600
-    tags = {
-        environment = "${var.env_name}"
-    }
+  name                              = "${var.env_name}-kms-es-events"
+  delay_seconds                     = 5
+  max_message_size                  = 2048
+  visibility_timeout_seconds        = 120
+  message_retention_seconds         = 345600 # 4 days
+  kms_master_key_id                 = aws_kms_key.kms_logging.arn
+  kms_data_key_reuse_period_seconds = 600
+  tags = {
+    environment = var.env_name
+  }
 }
 
-resource "aws_sqs_queue_policy" "es_events"{
-    queue_url = aws_sqs_queue.kms_elasticsearch_events.id
-    policy = data.aws_iam_policy_document.sqs_kms_es_events_policy.json
+resource "aws_sqs_queue_policy" "es_events" {
+  queue_url = aws_sqs_queue.kms_elasticsearch_events.id
+  policy    = data.aws_iam_policy_document.sqs_kms_es_events_policy.json
 }
 
 # elasticsearch queue policy
 data "aws_iam_policy_document" "sqs_kms_es_events_policy" {
-    statement {
-        sid = "Allow SNS"
-        effect = "Allow"
-        actions = ["sqs:SendMessage"]
-        principals {
-            type = "Service"
-            identifiers = [
-                "sns.amazonaws.com"
-            ]
-        }
-        resources = ["${aws_sqs_queue.kms_elasticsearch_events.arn}"]
-        condition {
-            test = "StringLike"
-            variable = "aws:SourceArn"
-            values = [
-                "${aws_sns_topic.kms_logging_events.arn}"
-            ]
-        }
+  statement {
+    sid     = "Allow SNS"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    principals {
+      type = "Service"
+      identifiers = [
+        "sns.amazonaws.com",
+      ]
     }
+    resources = [aws_sqs_queue.kms_elasticsearch_events.arn]
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values = [
+        aws_sns_topic.kms_logging_events.arn,
+      ]
+    }
+  }
 }
 
 # elasticsearch queue subscription to sns topic for metrics
 resource "aws_sns_topic_subscription" "kms_events_sqs_es_target" {
-    topic_arn = aws_sns_topic.kms_logging_events.arn
-    protocol  = "sqs"
-    endpoint  = aws_sqs_queue.kms_elasticsearch_events.arn
+  topic_arn = aws_sns_topic.kms_logging_events.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.kms_elasticsearch_events.arn
 }
 
 # create kinesis data stream for application kms events
 resource "aws_kinesis_stream" "datastream" {
-    name = "${var.env_name}-kms-app-events"
-    shard_count = var.kinesis_shard_count
-    retention_period = var.kinesis_retention_hours
-    encryption_type = "KMS"
-    kms_key_id="alias/aws/kinesis"
+  name             = "${var.env_name}-kms-app-events"
+  shard_count = var.kinesis_shard_count
+  
+  retention_period = var.kinesis_retention_hours
+  encryption_type  = "KMS"
+  kms_key_id       = "alias/aws/kinesis"
 
-    shard_level_metrics = [
-        "ReadProvisionedThroughputExceeded",
-        "WriteProvisionedThroughputExceeded"
-    ]
-    
-    tags = {
-        environment = "${var.env_name}"
-    }
+  shard_level_metrics = [
+    "ReadProvisionedThroughputExceeded",
+    "WriteProvisionedThroughputExceeded",
+  ]
+
+  tags = {
+    environment = var.env_name
+  }
 }
 
 # policy to allow kinesis access to cloudwatch
 data "aws_iam_policy_document" "assume_role" {
-    statement {
-        sid = "AssumeRole"
-        actions = ["sts:AssumeRole"]
+  statement {
+    sid     = "AssumeRole"
+    actions = ["sts:AssumeRole"]
 
-        principals {
-            type        = "Service"
-            identifiers = ["logs.${var.region}.amazonaws.com"]
-        }
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
     }
+  }
 }
 
 # policy to allow cloudwatch to put log records into kinesis
 data "aws_iam_policy_document" "cloudwatch_access" {
-   statement {
-     sid = "KinesisPut" 
-     effect = "Allow"
-     actions = [
-       "kinesis:PutRecord"
-     ]
-     resources = [
-       "${aws_kinesis_stream.datastream.arn}"
-     ]
-   }
+  statement {
+    sid    = "KinesisPut"
+    effect = "Allow"
+    actions = [
+      "kinesis:PutRecord",
+    ]
+    resources = [
+      aws_kinesis_stream.datastream.arn,
+    ]
+  }
 }
 
 # kinesis role 
 resource "aws_iam_role" "cloudwatch_to_kinesis" {
- name = local.kinesis_stream_name
- path = "/"
- assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name               = local.kinesis_stream_name
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 # add cloudwatch access to kinesis role
 resource "aws_iam_role_policy" "cloudwatch_access" {
-    name = "cloudwatch_access"
-    role = aws_iam_role.cloudwatch_to_kinesis.name
-    policy = data.aws_iam_policy_document.cloudwatch_access.json
+  name   = "cloudwatch_access"
+  role   = aws_iam_role.cloudwatch_to_kinesis.name
+  policy = data.aws_iam_policy_document.cloudwatch_access.json
 }
 
 # set cloudwatch destination
 resource "aws_cloudwatch_log_destination" "datastream" {
-    name = local.kinesis_stream_name
-    role_arn = aws_iam_role.cloudwatch_to_kinesis.arn
-    target_arn = aws_kinesis_stream.datastream.arn
+  name       = local.kinesis_stream_name
+  role_arn   = aws_iam_role.cloudwatch_to_kinesis.arn
+  target_arn = aws_kinesis_stream.datastream.arn
 }
 
 # configure policy to allow subscription acccess
 data "aws_iam_policy_document" "subscription" {
-    statement {
-        sid = "PutSubscription"
-        actions = ["logs:PutSubscriptionFilter"]
+  statement {
+    sid     = "PutSubscription"
+    actions = ["logs:PutSubscriptionFilter"]
 
-        principals {
-            type        = "AWS"
-            identifiers = ["${data.aws_caller_identity.current.account_id}"]
-        }
-
-        resources = [
-            "${aws_cloudwatch_log_destination.datastream.arn}"
-        ]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
     }
+
+    resources = [
+      aws_cloudwatch_log_destination.datastream.arn,
+    ]
+  }
 }
 
 # create destination polciy
 resource "aws_cloudwatch_log_destination_policy" "subscription" {
-    destination_name = aws_cloudwatch_log_destination.datastream.name
-    access_policy = data.aws_iam_policy_document.subscription.json
+  destination_name = aws_cloudwatch_log_destination.datastream.name
+  access_policy    = data.aws_iam_policy_document.subscription.json
 }
 
 # create subscription filter 
 # this filter will send the kms.log events to kinesis
 resource "aws_cloudwatch_log_subscription_filter" "kinesis" {
-    depends_on = [null_resource.kms_log_found]
-    count = var.kmslogging_service_enabled
-    name = "${var.env_name}-kms-app-log"
-    log_group_name = "${var.env_name}_/srv/idp/shared/log/kms.log"
-    filter_pattern = var.cloudwatch_filter_pattern
-    destination_arn = aws_kinesis_stream.datastream.arn
-    role_arn = aws_iam_role.cloudwatch_to_kinesis.arn
+  depends_on      = [null_resource.kms_log_found]
+  count = var.kmslogging_service_enabled
+  
+  name            = "${var.env_name}-kms-app-log"
+  log_group_name  = "${var.env_name}_/srv/idp/shared/log/kms.log"
+  filter_pattern  = var.cloudwatch_filter_pattern
+  destination_arn = aws_kinesis_stream.datastream.arn
+  role_arn        = aws_iam_role.cloudwatch_to_kinesis.arn
 }
 
 resource "aws_cloudwatch_dashboard" "kms_log" {
-    dashboard_name = local.dashboard_name
-    dashboard_body = <<EOF
+  dashboard_name = local.dashboard_name
+  dashboard_body = <<EOF
 {
     "widgets": [
         {
@@ -611,518 +620,536 @@ resource "aws_cloudwatch_dashboard" "kms_log" {
     ]
 }
 EOF
+
 }
 
 resource "aws_cloudwatch_metric_alarm" "dead_letter" {
-    alarm_name = "${var.env_name}-kms_log_dead_letter"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    evaluation_periods = 1
-    metric_name = "NumberOfMessagesReceived"
-    namespace = "AWS/SQS"
-    dimensions = {
-        QueueName = "${aws_sqs_queue.dead_letter.name}"
-    }
-    period = "180"
-    statistic = "Sum"
-    threshold = 1
-    alarm_description = "This alarm notifies when messages are on dead letter queue"
-    treat_missing_data = "ignore"
-    alarm_actions = [
-        "${var.sns_topic_dead_letter_arn}"
-    ]
+  alarm_name          = "${var.env_name}-kms_log_dead_letter"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "NumberOfMessagesReceived"
+  namespace           = "AWS/SQS"
+  dimensions = {
+    QueueName = aws_sqs_queue.dead_letter.name
+  }
+  period             = "180"
+  statistic          = "Sum"
+  threshold          = 1
+  alarm_description  = "This alarm notifies when messages are on dead letter queue"
+  treat_missing_data = "ignore"
+  alarm_actions = [
+    var.sns_topic_dead_letter_arn,
+  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_lambda_backlog" {
-    alarm_name = "${var.env_name}-cloudwatch-kms-backlog"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    evaluation_periods = 1
-    namespace = "AWS/Lambda"
-    metric_name = "IteratorAge"
-    dimensions = {
-        FunctionName = "${local.cw_processor_lambda_name}"
-    }
-    period = "180"
-    statistic = "Maximum"
-    # 3600000 ms = 1 hour
-    threshold = 3600000
-    alarm_description = "Kinesis backlog for ${var.env_name}-cloudwatch-kms"
-    treat_missing_data = "ignore"
-    alarm_actions = [
-        "${aws_sns_topic.kms_logging_events.arn}"
-    ]
+  alarm_name          = "${var.env_name}-cloudwatch-kms-backlog"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  namespace           = "AWS/Lambda"
+  metric_name         = "IteratorAge"
+  dimensions = {
+    FunctionName = local.cw_processor_lambda_name
+  }
+  period    = "180"
+  statistic = "Maximum"
+
+  # 3600000 ms = 1 hour
+  threshold          = 3600000
+  alarm_description  = "Kinesis backlog for ${var.env_name}-cloudwatch-kms"
+  treat_missing_data = "ignore"
+  alarm_actions = [
+    aws_sns_topic.kms_logging_events.arn,
+  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudtrail_lambda_backlog" {
-    alarm_name = "${var.env_name}-cloudtrail-kms-backlog"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    evaluation_periods = 1
-    metric_name = "ApproximateNumberOfMessagesVisible"
-    namespace = "AWS/SQS"
-    dimensions = {
-        QueueName = "${aws_sqs_queue.kms_ct_events.name}"
-    }
-    period = "180"
-    statistic = "Maximum"
-    # the previous alarm is measured in milliseconds, this is a raw number of
-    # messages - it has never gone above 1, but if the Lambda breaks it will
-    # get to 10000 in under an hour
-    threshold = 10000
-    alarm_description = "Kinesis backlog for ${var.env_name}-cloudtrail-kms"
-    treat_missing_data = "ignore"
-    alarm_actions = [
-        "${aws_sns_topic.kms_logging_events.arn}"
-    ]
+  alarm_name          = "${var.env_name}-cloudtrail-kms-backlog"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  dimensions = {
+    QueueName = aws_sqs_queue.kms_ct_events.name
+  }
+  period    = "180"
+  statistic = "Maximum"
+
+  # the previous alarm is measured in milliseconds, this is a raw number of
+  # messages - it has never gone above 1, but if the Lambda breaks it will
+  # get to 10000 in under an hour
+  threshold          = 10000
+  alarm_description  = "Kinesis backlog for ${var.env_name}-cloudtrail-kms"
+  treat_missing_data = "ignore"
+  alarm_actions = [
+    aws_sns_topic.kms_logging_events.arn,
+  ]
 }
 
 #lambda functions
 resource "aws_lambda_function" "cloudtrail_processor" {
-    count = var.kmslogging_service_enabled
-    s3_bucket = data.aws_s3_bucket.lambda.id
-    s3_key = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
+  count = var.kmslogging_service_enabled
+  
+  s3_bucket = data.aws_s3_bucket.lambda.id
+  s3_key    = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
 
-    lifecycle {
-        ignore_changes = [s3_key, last_modified]
+  lifecycle {
+    ignore_changes = [
+      s3_key,
+      last_modified,
+    ]
+  }
+
+  function_name = local.ct_processor_lambda_name
+  description   = "18F/identity-lambda-functions: KMS CT Log Processor"
+  role          = aws_iam_role.cloudtrail_processor.arn
+  handler       = "main.Functions::IdentityKMSMonitor::CloudTrailToDynamoHandler.process"
+  runtime       = "ruby2.5"
+  timeout       = 120 # seconds
+
+  environment {
+    variables = {
+      DEBUG               = var.kmslog_lambda_debug ? "1" : ""
+      LOG_LEVEL           = "0"
+      CT_QUEUE_URL        = aws_sqs_queue.kms_ct_events.id
+      RETENTION_DAYS      = var.dynamodb_retention_days
+      DDB_TABLE           = aws_dynamodb_table.kms_events.id
+      SNS_EVENT_TOPIC_ARN = aws_sns_topic.kms_logging_events.arn
     }
+  }
 
-    function_name = local.ct_processor_lambda_name
-    description = "18F/identity-lambda-functions: KMS CT Log Processor"
-    role = aws_iam_role.cloudtrail_processor.arn
-    handler = "main.Functions::IdentityKMSMonitor::CloudTrailToDynamoHandler.process"
-    runtime = "ruby2.5"
-    timeout = 120 # seconds
-
-    environment {
-        variables = {
-            DEBUG = "${var.kmslog_lambda_debug == 1 ? "1" : ""}"
-            LOG_LEVEL = "0"
-            CT_QUEUE_URL = "${aws_sqs_queue.kms_ct_events.id}"
-            RETENTION_DAYS = "${var.dynamodb_retention_days}"
-            DDB_TABLE = "${aws_dynamodb_table.kms_events.id}"
-            SNS_EVENT_TOPIC_ARN = "${aws_sns_topic.kms_logging_events.arn}"
-        }
-    }
-
-    tags = {
-        source_repo = "https://github.com/18F/identity-lambda-functions"
-        environment = "${var.env_name}"
-    }
+  tags = {
+    source_repo = "https://github.com/18F/identity-lambda-functions"
+    environment = var.env_name
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "cloudtrail_processor" {
-    count = var.kmslogging_service_enabled
-    event_source_arn = aws_sqs_queue.kms_ct_events.arn
-    function_name = aws_lambda_function.cloudtrail_processor[count.index].arn
+  count = var.kmslogging_service_enabled
+  
+  event_source_arn = aws_sqs_queue.kms_ct_events.arn
+  function_name    = aws_lambda_function.cloudtrail_processor[0].arn
 }
 
-
 data "aws_iam_policy_document" "ctprocessor_cloudwatch" {
-    statement {
-        sid = "CreateLogGroup"
-        effect = "Allow"
-        actions = [
-            "logs:CreateLogGroup"
-        ]
+  statement {
+    sid    = "CreateLogGroup"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+    ]
 
-        resources = [
-            "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*",
-        ]
-    }
-    statement {
-        sid = "PutLogEvents"
-        effect = "Allow"
-        actions = [
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-        ]
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*",
+    ]
+  }
+  statement {
+    sid    = "PutLogEvents"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
 
-        resources = [
-            "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.ct_processor_lambda_name}:*"
-        ]
-    }
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.ct_processor_lambda_name}:*",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "lambda_kms" {
-    statement {
-        sid = "KMS"
-        effect = "Allow"
-        actions = [
-            "kms:Decrypt",
-            "kms:GenerateDataKey"
-        ]
+  statement {
+    sid    = "KMS"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
 
-        resources = [
-            "${aws_kms_key.kms_logging.arn}"
-        ]
-    }
+    resources = [
+      aws_kms_key.kms_logging.arn,
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "lambda_dynamodb" {
-    statement {
-        sid = "DynamoDb"
-        effect = "Allow"
-        actions = [
-            "dynamodb:PutItem",
-            "dynamodb:GetItem",
-            "dynamodb:Query"
-        ]
+  statement {
+    sid    = "DynamoDb"
+    effect = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+    ]
 
-        resources = [
-            "${aws_dynamodb_table.kms_events.arn}"
-        ]
-    }
+    resources = [
+      aws_dynamodb_table.kms_events.arn,
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "ctprocessor_sns" {
-    statement {
-        sid = "ctprocessorSNS"
-        effect = "Allow"
-        actions = [
-            "sns:Publish"
-        ]
+  statement {
+    sid    = "ctprocessorSNS"
+    effect = "Allow"
+    actions = [
+      "sns:Publish",
+    ]
 
-        resources = [
-            "${aws_sns_topic.kms_logging_events.arn}"
-        ]
-    }
+    resources = [
+      aws_sns_topic.kms_logging_events.arn,
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "ctprocessor_sqs" {
-    statement {
-        sid = "SQS"
-        effect = "Allow"
-        actions = [
-            "sqs:DeleteMessage",
-            "sqs:ChangeMessageVisibility",
-            "sqs:ReceiveMessage",
-            "sqs:SendMessage",
-            "sqs:GetQueueAttributes"
-        ]
+  statement {
+    sid    = "SQS"
+    effect = "Allow"
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+      "sqs:GetQueueAttributes",
+    ]
 
-        resources = [
-            "${aws_sqs_queue.kms_ct_events.arn}"
-        ]
-    }
+    resources = [
+      aws_sqs_queue.kms_ct_events.arn,
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "assume-role" {
-    statement {
-        actions = [
-            "sts:AssumeRole"
-        ]
-        principals {
-            type = "Service"
-            identifiers = [
-                "lambda.amazonaws.com"
-            ]
-        }
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "lambda.amazonaws.com",
+      ]
     }
+  }
 }
 
 resource "aws_iam_role" "cloudtrail_processor" {
-    name = "${local.ct_processor_lambda_name}-execution"
-    assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  name               = "${local.ct_processor_lambda_name}-execution"
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy" "ctprocessor_cloudwatch" {
-    name = "ctprocessor_cloudwatch"
-    role = aws_iam_role.cloudtrail_processor.id
-    policy = data.aws_iam_policy_document.ctprocessor_cloudwatch.json
+  name   = "ctprocessor_cloudwatch"
+  role   = aws_iam_role.cloudtrail_processor.id
+  policy = data.aws_iam_policy_document.ctprocessor_cloudwatch.json
 }
 
 resource "aws_iam_role_policy" "ctprocessor_dynamodb" {
-    name = "ctprocessor_dynamodb"
-    role = aws_iam_role.cloudtrail_processor.id
-    policy = data.aws_iam_policy_document.lambda_dynamodb.json
+  name   = "ctprocessor_dynamodb"
+  role   = aws_iam_role.cloudtrail_processor.id
+  policy = data.aws_iam_policy_document.lambda_dynamodb.json
 }
 
 resource "aws_iam_role_policy" "ctprocessor_kms" {
-    name = "ctprocessor_kms"
-    role = aws_iam_role.cloudtrail_processor.id
-    policy = data.aws_iam_policy_document.lambda_kms.json
+  name   = "ctprocessor_kms"
+  role   = aws_iam_role.cloudtrail_processor.id
+  policy = data.aws_iam_policy_document.lambda_kms.json
 }
 
 resource "aws_iam_role_policy" "ctprocessor_sns" {
-    name = "ctprocessor_sns"
-    role = aws_iam_role.cloudtrail_processor.id
-    policy = data.aws_iam_policy_document.ctprocessor_sns.json
+  name   = "ctprocessor_sns"
+  role   = aws_iam_role.cloudtrail_processor.id
+  policy = data.aws_iam_policy_document.ctprocessor_sns.json
 }
 
 resource "aws_iam_role_policy" "ctprocessor_sqs" {
-    name = "ctprocessor_sqs"
-    role = aws_iam_role.cloudtrail_processor.id
-    policy = data.aws_iam_policy_document.ctprocessor_sqs.json
+  name   = "ctprocessor_sqs"
+  role   = aws_iam_role.cloudtrail_processor.id
+  policy = data.aws_iam_policy_document.ctprocessor_sqs.json
 }
 
 resource "aws_lambda_function" "cloudwatch_processor" {
-    count = var.kmslogging_service_enabled
-    s3_bucket = data.aws_s3_bucket.lambda.id
-    s3_key = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
+  count = var.kmslogging_service_enabled
+  
+  s3_bucket = data.aws_s3_bucket.lambda.id
+  s3_key    = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
 
-    lifecycle {
-        ignore_changes = [s3_key, last_modified]
+  lifecycle {
+    ignore_changes = [
+      s3_key,
+      last_modified,
+    ]
+  }
+
+  function_name = local.cw_processor_lambda_name
+  description   = "18F/identity-lambda-functions: KMS CW Log Processor"
+  role          = aws_iam_role.cloudwatch_processor.arn
+  handler       = "main.Functions::IdentityKMSMonitor::CloudWatchKMSHandler.process"
+  runtime       = "ruby2.5"
+  timeout       = 120 # seconds
+
+  environment {
+    variables = {
+      DEBUG               = var.kmslog_lambda_debug ? "1" : ""
+      LOG_LEVEL           = "0"
+      RETENTION_DAYS      = var.dynamodb_retention_days
+      DDB_TABLE           = aws_dynamodb_table.kms_events.id
+      SNS_EVENT_TOPIC_ARN = aws_sns_topic.kms_logging_events.arn
     }
+  }
 
-    function_name = local.cw_processor_lambda_name
-    description = "18F/identity-lambda-functions: KMS CW Log Processor"
-    role = aws_iam_role.cloudwatch_processor.arn
-    handler = "main.Functions::IdentityKMSMonitor::CloudWatchKMSHandler.process"
-    runtime = "ruby2.5"
-    timeout = 120 # seconds
-
-    environment {
-        variables = {
-            DEBUG = "${var.kmslog_lambda_debug == 1 ? "1" : ""}"
-            LOG_LEVEL = "0"
-            RETENTION_DAYS = "${var.dynamodb_retention_days}"
-            DDB_TABLE = "${aws_dynamodb_table.kms_events.id}"
-            SNS_EVENT_TOPIC_ARN = "${aws_sns_topic.kms_logging_events.arn}"
-        }
-    }
-
-    tags = {
-        source_repo = "https://github.com/18F/identity-lambda-functions"
-        environment = "${var.env_name}"
-    }
+  tags = {
+    source_repo = "https://github.com/18F/identity-lambda-functions"
+    environment = var.env_name
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "cloudwatch_processor" {
-    count = var.kmslogging_service_enabled
-    event_source_arn = aws_kinesis_stream.datastream.arn
-    function_name = aws_lambda_function.cloudwatch_processor[count.index].arn
-    starting_position = "LATEST"
+  count = var.kmslogging_service_enabled
+  
+  event_source_arn  = aws_kinesis_stream.datastream.arn
+  function_name     = aws_lambda_function.cloudwatch_processor[0].arn
+  starting_position = "LATEST"
 }
 
 resource "aws_iam_role" "cloudwatch_processor" {
-    name = "${local.cw_processor_lambda_name}-execution"
-    assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  name               = "${local.cw_processor_lambda_name}-execution"
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "cwprocessor_cloudwatch" {
-    statement {
-        sid = "CreateLogGroup"
-        effect = "Allow"
-        actions = [
-            "logs:CreateLogGroup"
-        ]
+  statement {
+    sid    = "CreateLogGroup"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+    ]
 
-        resources = [
-            "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*",
-        ]
-    }
-    statement {
-        sid = "PutLogEvents"
-        effect = "Allow"
-        actions = [
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-        ]
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*",
+    ]
+  }
+  statement {
+    sid    = "PutLogEvents"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
 
-        resources = [
-            "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.cw_processor_lambda_name}:*"
-        ]
-    }
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.cw_processor_lambda_name}:*",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "cwprocessor_sns" {
-    statement {
-        sid = "cwprocessorSNS"
-        effect = "Allow"
-        actions = [
-            "sns:Publish"
-        ]
+  statement {
+    sid    = "cwprocessorSNS"
+    effect = "Allow"
+    actions = [
+      "sns:Publish",
+    ]
 
-        resources = [
-            "${aws_sns_topic.kms_logging_events.arn}"
-        ]
-    }
+    resources = [
+      aws_sns_topic.kms_logging_events.arn,
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "cwprocessor_kinesis" {
-    statement {
-        sid = "Kinesis"
-        effect = "Allow"
-        actions = [
-            "kinesis:GetShardIterator",
-            "kinesis:GetRecords",
-            "kinesis:DescribeStream"
-        ]
+  statement {
+    sid    = "Kinesis"
+    effect = "Allow"
+    actions = [
+      "kinesis:GetShardIterator",
+      "kinesis:GetRecords",
+      "kinesis:DescribeStream",
+    ]
 
-        resources = [
-            "${aws_kinesis_stream.datastream.arn}"
-        ]
-    }
+    resources = [
+      aws_kinesis_stream.datastream.arn,
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "cwprocessor_cloudwatch" {
-    name = "cwprocessor_cloudwatch"
-    role = aws_iam_role.cloudwatch_processor.id
-    policy = data.aws_iam_policy_document.cwprocessor_cloudwatch.json
+  name   = "cwprocessor_cloudwatch"
+  role   = aws_iam_role.cloudwatch_processor.id
+  policy = data.aws_iam_policy_document.cwprocessor_cloudwatch.json
 }
 
 resource "aws_iam_role_policy" "cwprocessor_dynamodb" {
-    name = "cwprocessor_dynamodb"
-    role = aws_iam_role.cloudwatch_processor.id
-    policy = data.aws_iam_policy_document.lambda_dynamodb.json
+  name   = "cwprocessor_dynamodb"
+  role   = aws_iam_role.cloudwatch_processor.id
+  policy = data.aws_iam_policy_document.lambda_dynamodb.json
 }
 
 resource "aws_iam_role_policy" "cwprocessor_kms" {
-    name = "cwprocessor_kms"
-    role = aws_iam_role.cloudwatch_processor.id
-    policy = data.aws_iam_policy_document.lambda_kms.json
+  name   = "cwprocessor_kms"
+  role   = aws_iam_role.cloudwatch_processor.id
+  policy = data.aws_iam_policy_document.lambda_kms.json
 }
 
 resource "aws_iam_role_policy" "cwprocessor_sns" {
-    name = "cwprocessor_sns"
-    role = aws_iam_role.cloudwatch_processor.id
-    policy = data.aws_iam_policy_document.cwprocessor_sns.json
+  name   = "cwprocessor_sns"
+  role   = aws_iam_role.cloudwatch_processor.id
+  policy = data.aws_iam_policy_document.cwprocessor_sns.json
 }
 
 resource "aws_iam_role_policy" "cwprocessor_kinesis" {
-    name = "cwprocessor_kinesis"
-    role = aws_iam_role.cloudwatch_processor.id
-    policy = data.aws_iam_policy_document.cwprocessor_kinesis.json
+  name   = "cwprocessor_kinesis"
+  role   = aws_iam_role.cloudwatch_processor.id
+  policy = data.aws_iam_policy_document.cwprocessor_kinesis.json
 }
 
 # lambda for creating cloudwatch metrics and events
 resource "aws_lambda_function" "event_processor" {
-    count = var.kmslogging_service_enabled
-    s3_bucket = data.aws_s3_bucket.lambda.id
-    s3_key = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
+  count = var.kmslogging_service_enabled
+  
+  s3_bucket = data.aws_s3_bucket.lambda.id
+  s3_key    = "circleci/identity-lambda-functions/${var.lambda_identity_lambda_functions_gitrev}.zip"
 
-    lifecycle {
-        ignore_changes = [s3_key, last_modified]
+  lifecycle {
+    ignore_changes = [
+      s3_key,
+      last_modified,
+    ]
+  }
+
+  function_name = local.event_processor_lambda_name
+  description   = "18F/identity-lambda-functions: KMS Log Event Processor"
+  role          = aws_iam_role.event_processor.arn
+  handler       = "main.Functions::IdentityKMSMonitor::CloudWatchEventGenerator.process"
+  runtime       = "ruby2.5"
+  timeout       = 120 # seconds
+
+  environment {
+    variables = {
+      DEBUG     = var.kmslog_lambda_debug ? "1" : ""
+      LOG_LEVEL = "0"
+      ENV_NAME  = var.env_name
     }
+  }
 
-    function_name = local.event_processor_lambda_name
-    description = "18F/identity-lambda-functions: KMS Log Event Processor"
-    role = aws_iam_role.event_processor.arn
-    handler = "main.Functions::IdentityKMSMonitor::CloudWatchEventGenerator.process"
-    runtime = "ruby2.5"
-    timeout = 120 # seconds
-
-    environment {
-        variables = {
-            DEBUG = "${var.kmslog_lambda_debug == 1 ? "1" : ""}"
-            LOG_LEVEL = "0"
-            ENV_NAME = "${var.env_name}"
-        }
-    }
-
-    tags = {
-        source_repo = "https://github.com/18F/identity-lambda-functions"
-        environment = "${var.env_name}"
-    }
+  tags = {
+    source_repo = "https://github.com/18F/identity-lambda-functions"
+    environment = var.env_name
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "event_processor" {
-    count = var.kmslogging_service_enabled
-    event_source_arn = aws_sqs_queue.kms_cloudwatch_events.arn
-    function_name = aws_lambda_function.event_processor[count.index].arn
+  count = var.kmslogging_service_enabled
+  
+  event_source_arn = aws_sqs_queue.kms_cloudwatch_events.arn
+  function_name    = aws_lambda_function.event_processor[0].arn
 }
 
 resource "aws_iam_role" "event_processor" {
-    name = "${local.event_processor_lambda_name}-execution"
-    assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  name               = "${local.event_processor_lambda_name}-execution"
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "event_processor_cloudwatch" {
-    statement {
-        sid = "CreateLogGroup"
-        effect = "Allow"
-        actions = [
-            "logs:CreateLogGroup"
-        ]
+  statement {
+    sid    = "CreateLogGroup"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+    ]
 
-        resources = [
-            "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*",
-        ]
-    }
-    statement {
-        sid = "PutLogEvents"
-        effect = "Allow"
-        actions = [
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-        ]
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*",
+    ]
+  }
+  statement {
+    sid    = "PutLogEvents"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
 
-        resources = [
-            "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.event_processor_lambda_name}:*"
-        ]
-    }
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.event_processor_lambda_name}:*",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "event_processor_cloudwatch_events" {
-    statement {
-        sid = "CloudWatchEvents"
-        effect = "Allow"
-        actions = [
-            "events:PutEvents"
-        ]
+  statement {
+    sid    = "CloudWatchEvents"
+    effect = "Allow"
+    actions = [
+      "events:PutEvents",
+    ]
 
-        resources = [
-            "*"
-        ]
-    }
+    resources = [
+      "*",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "event_processor_cloudwatch_metrics" {
-    statement {
-        sid = "CloudWatchMetrics"
-        effect = "Allow"
-        actions = [
-            "cloudwatch:PutMetricData"
-        ]
+  statement {
+    sid    = "CloudWatchMetrics"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
 
-        resources = [
-            "*"
-        ]
-    }
+    resources = [
+      "*",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "event_processor_sqs" {
-    statement {
-        sid = "SQS"
-        effect = "Allow"
-        actions = [
-            "sqs:DeleteMessage",
-            "sqs:ChangeMessageVisibility",
-            "sqs:ReceiveMessage",
-            "sqs:SendMessage",
-            "sqs:GetQueueAttributes"
-        ]
+  statement {
+    sid    = "SQS"
+    effect = "Allow"
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+      "sqs:GetQueueAttributes",
+    ]
 
-        resources = [
-            "${aws_sqs_queue.kms_cloudwatch_events.arn}"
-        ]
-    }
+    resources = [
+      aws_sqs_queue.kms_cloudwatch_events.arn,
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "event_processor_cloudwatch" {
-    name = "CloudWatch"
-    role = aws_iam_role.event_processor.id
-    policy = data.aws_iam_policy_document.event_processor_cloudwatch.json
+  name   = "CloudWatch"
+  role   = aws_iam_role.event_processor.id
+  policy = data.aws_iam_policy_document.event_processor_cloudwatch.json
 }
 
 resource "aws_iam_role_policy" "event_processor_cloudwatch_events" {
-    name = "CloudWatchEvents"
-    role = aws_iam_role.event_processor.id
-    policy = data.aws_iam_policy_document.event_processor_cloudwatch_events.json
+  name   = "CloudWatchEvents"
+  role   = aws_iam_role.event_processor.id
+  policy = data.aws_iam_policy_document.event_processor_cloudwatch_events.json
 }
 
 resource "aws_iam_role_policy" "event_processor_cloudwatch_metrics" {
-    name = "CloudWatchMetrics"
-    role = aws_iam_role.event_processor.id
-    policy = data.aws_iam_policy_document.event_processor_cloudwatch_metrics.json
+  name   = "CloudWatchMetrics"
+  role   = aws_iam_role.event_processor.id
+  policy = data.aws_iam_policy_document.event_processor_cloudwatch_metrics.json
 }
 
 resource "aws_iam_role_policy" "event_processor_kms" {
-    name = "event_processor_kms"
-    role = aws_iam_role.event_processor.id
-    policy = data.aws_iam_policy_document.lambda_kms.json
+  name   = "event_processor_kms"
+  role   = aws_iam_role.event_processor.id
+  policy = data.aws_iam_policy_document.lambda_kms.json
 }
 
 resource "aws_iam_role_policy" "event_processor_sqs" {
-    name = "SQS"
-    role = aws_iam_role.event_processor.id
-    policy = data.aws_iam_policy_document.event_processor_sqs.json
+  name   = "SQS"
+  role   = aws_iam_role.event_processor.id
+  policy = data.aws_iam_policy_document.event_processor_sqs.json
 }
+

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -693,7 +693,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 
     environment {
         variables = {
-            DEBUG = "${var.kmslog_lambda_debug ? "1" : ""}"
+            DEBUG = "${var.kmslog_lambda_debug == 1 ? "1" : ""}"
             LOG_LEVEL = "0"
             CT_QUEUE_URL = "${aws_sqs_queue.kms_ct_events.id}"
             RETENTION_DAYS = "${var.dynamodb_retention_days}"
@@ -871,7 +871,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 
     environment {
         variables = {
-            DEBUG = "${var.kmslog_lambda_debug ? "1" : ""}"
+            DEBUG = "${var.kmslog_lambda_debug == 1 ? "1" : ""}"
             LOG_LEVEL = "0"
             RETENTION_DAYS = "${var.dynamodb_retention_days}"
             DDB_TABLE = "${aws_dynamodb_table.kms_events.id}"
@@ -1002,7 +1002,7 @@ resource "aws_lambda_function" "event_processor" {
 
     environment {
         variables = {
-            DEBUG = "${var.kmslog_lambda_debug ? "1" : ""}"
+            DEBUG = "${var.kmslog_lambda_debug == 1 ? "1" : ""}"
             LOG_LEVEL = "0"
             ENV_NAME = "${var.env_name}"
         }

--- a/kms_log/output.tf
+++ b/kms_log/output.tf
@@ -1,24 +1,25 @@
 output "kms-dead-letter-queue" {
-    description = "Arn for the kms dead letter queue"
-    value = "${aws_sqs_queue.dead_letter.arn}"
+  description = "Arn for the kms dead letter queue"
+  value       = aws_sqs_queue.dead_letter.arn
 }
 
 output "kms-ct-events-queue" {
-    description = "Arn for the kms cloudtrail queue"
-    value = "${aws_sqs_queue.kms_ct_events.arn}"
+  description = "Arn for the kms cloudtrail queue"
+  value       = aws_sqs_queue.kms_ct_events.arn
 }
 
 output "kms-logging-events-topic" {
-    description = "SNS topic for kms logging events"
-    value = "${aws_sns_topic.kms_logging_events.arn}"
+  description = "SNS topic for kms logging events"
+  value       = aws_sns_topic.kms_logging_events.arn
 }
 
 output "kms-elasticsearch-events-queue" {
-    description = "Queue for kms logging events to elasticsearch"
-    value = "${aws_sqs_queue.kms_elasticsearch_events.arn}"
+  description = "Queue for kms logging events to elasticsearch"
+  value       = aws_sqs_queue.kms_elasticsearch_events.arn
 }
 
 output "kms-cloudwatch-events-queue" {
-    description = "Queue for kms logging events to cloudwatch"
-    value = "${aws_sqs_queue.kms_cloudwatch_events.arn}"
+  description = "Queue for kms logging events to cloudwatch"
+  value       = aws_sqs_queue.kms_cloudwatch_events.arn
 }
+

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -3,54 +3,54 @@ variable "env_name" {
 }
 
 variable "region" {
-  default = "us-west-2"
+  default     = "us-west-2"
   description = "AWS Region"
 }
 
 variable "kmslogging_service_enabled" {
-  default = 0
+  default     = 0
   description = "Enable KMS Logging service.  If disabled the CloudWatch rule will not be created."
 }
 
 variable "kinesis_shard_count" {
-  default = 1
+  default     = 1
   description = "Number of shards to allocate to Kinesis data stream"
 }
 
 variable "kinesis_retention_hours" {
-  default = 24
+  default     = 24
   description = "Number of hours to retain data in Kinesis data stream.  Max = 168"
 }
 
 # this filter will parse and only send log events that have
 # an encryption context of pii-encryption or password-digest
 variable "cloudwatch_filter_pattern" {
-  default = "[type, datetime, info, whitespace, (json = *decrypt* && json = *pii-encryption*) || (json = *decrypt* && json = *password-digest*)]"
+  default     = "[type, datetime, info, whitespace, (json = *decrypt* && json = *pii-encryption*) || (json = *decrypt* && json = *password-digest*)]"
   description = "Filter pattern for CloudWatch kms.log file"
 }
 
 variable "ct_queue_delay_seconds" {
-  default = 60
+  default     = 60
   description = "Number of seconds after the message is placed on the queue before it is able to be received"
 }
 
 variable "ct_queue_max_message_size" {
-  default = 2048
+  default     = 2048
   description = "Max message size in kb"
 }
 
 variable "ct_queue_visibility_timeout_seconds" {
-  default = 120
+  default     = 120
   description = "Number of seconds that a received message is not visible to other workers"
 }
 
 variable "ct_queue_message_retention_seconds" {
-  default = 345600 # 4 days
+  default     = 345600 # 4 days
   description = "Number of seconds a message will remain in the queue"
 }
 
 variable "ct_queue_maxreceivecount" {
-  default = 10
+  default     = 10
   description = "Number of times a message will be received before going to the deadletter queue"
 }
 
@@ -59,16 +59,17 @@ variable "sns_topic_dead_letter_arn" {
 }
 
 variable "lambda_identity_lambda_functions_gitrev" {
-  default = "40a8d2e68705313599e972a1cf50fd5a897ecc45"
+  default     = "40a8d2e68705313599e972a1cf50fd5a897ecc45"
   description = "Initial gitrev of identity-lambda-functions to deploy (updated outside of terraform)"
 }
 
 variable "dynamodb_retention_days" {
-  default = "365"
+  default     = "365"
   description = "Number of days to retain kms log records in dynamodb"
 }
 
 variable "kmslog_lambda_debug" {
-  default = 0
+  default     = 0
   description = "Whether to run the kms logging lambdas in debug mode in this account"
 }
+

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -77,7 +77,6 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
     }
 
     datapoints_to_alarm = "${var.datapoints_to_alarm}"
-    evaluation_periods = "${var.evaluation_periods}"
 
     treat_missing_data = "${var.treat_missing_data}"
 

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -8,7 +8,7 @@ data "aws_lambda_function" "func" {
 }
 
 variable "alarm_actions" {
-    type = "list"
+    type = list
     description = "A list of ARNs to notify when the alarm fires"
 }
 
@@ -41,8 +41,8 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
 
     comparison_operator = "GreaterThanOrEqualToThreshold"
 
-    evaluation_periods = "${var.evaluation_periods}"
-    threshold = "${var.error_rate_threshold}"
+    evaluation_periods = var.evaluation_periods
+    threshold = var.error_rate_threshold
     insufficient_data_actions = []
 
     metric_query {
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
             dimensions = {
                 FunctionName = "${var.function_name}"
             }
-            period = "${var.period}"
+            period = var.period
             stat = "Sum"
         }
     }
@@ -71,14 +71,14 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
             dimensions = {
                 FunctionName = "${var.function_name}"
             }
-            period = "${var.period}"
+            period = var.period
             stat = "Sum"
         }
     }
 
-    datapoints_to_alarm = "${var.datapoints_to_alarm}"
+    datapoints_to_alarm = var.datapoints_to_alarm
 
-    treat_missing_data = "${var.treat_missing_data}"
+    treat_missing_data = var.treat_missing_data
 
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = var.alarm_actions
 }

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -1,84 +1,86 @@
 variable "function_name" {
-    description = "Name of the lambda function to monitor"
+  description = "Name of the lambda function to monitor"
 }
 
 # make sure that the function exists
 data "aws_lambda_function" "func" {
-  function_name = "${var.function_name}"
+  function_name = var.function_name
 }
 
 variable "alarm_actions" {
-    type = list
-    description = "A list of ARNs to notify when the alarm fires"
+  type        = list(string)
+  description = "A list of ARNs to notify when the alarm fires"
 }
 
 variable "error_rate_threshold" {
-    description = "The threshold error rate (as a percentage) for triggering an alert"
-    default = 1
+  description = "The threshold error rate (as a percentage) for triggering an alert"
+  default     = 1
 }
 
 variable "datapoints_to_alarm" {
-    description = "The number of datapoints that must be breaching to trigger the alarm."
-    default = 1
+  description = "The number of datapoints that must be breaching to trigger the alarm."
+  default     = 1
 }
 
 variable "evaluation_periods" {
-    default = 1
+  default = 1
 }
 
 variable "period" {
-    description = "The period in seconds over which the specified statistic is applied."
-    default = 60
+  description = "The period in seconds over which the specified statistic is applied."
+  default     = 60
 }
 
 variable "treat_missing_data" {
-    default = "missing"
+  default = "missing"
 }
 
 resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
-    alarm_name = "Lambda error rate: ${var.function_name}"
-    alarm_description = "Lambda error rate has exceeded ${var.error_rate_threshold}%"
+  alarm_name        = "Lambda error rate: ${var.function_name}"
+  alarm_description = "Lambda error rate has exceeded ${var.error_rate_threshold}%"
 
-    comparison_operator = "GreaterThanOrEqualToThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
 
-    evaluation_periods = var.evaluation_periods
-    threshold = var.error_rate_threshold
-    insufficient_data_actions = []
+  evaluation_periods        = var.evaluation_periods
+  threshold                 = var.error_rate_threshold
+  insufficient_data_actions = []
 
-    metric_query {
-        id = "error_rate"
-        expression = "errors / invocations * 100"
-        label = "Error Rate"
-        return_data = "true"
+  metric_query {
+    id          = "error_rate"
+    expression  = "errors / invocations * 100"
+    label       = "Error Rate"
+    return_data = "true"
+  }
+  metric_query {
+    id = "errors"
+    metric {
+      metric_name = "Errors"
+      namespace   = "AWS/Lambda"
+      dimensions = {
+        FunctionName = var.function_name
+      }
+      period = var.period
+      stat   = "Sum"
     }
-    metric_query {
-        id = "errors"
-        metric {
-            metric_name = "Errors"
-            namespace = "AWS/Lambda"
-            dimensions = {
-                FunctionName = "${var.function_name}"
-            }
-            period = var.period
-            stat = "Sum"
-        }
+  }
+  metric_query {
+    id = "invocations"
+    metric {
+      metric_name = "Invocations"
+      namespace   = "AWS/Lambda"
+      dimensions = {
+        FunctionName = var.function_name
+      }
+      period = var.period
+      stat   = "Sum"
     }
-    metric_query {
-        id = "invocations"
-        metric {
-            metric_name = "Invocations"
-            namespace = "AWS/Lambda"
-            dimensions = {
-                FunctionName = "${var.function_name}"
-            }
-            period = var.period
-            stat = "Sum"
-        }
-    }
+  }
 
-    datapoints_to_alarm = var.datapoints_to_alarm
+  datapoints_to_alarm = var.datapoints_to_alarm
+  evaluation_periods  = var.evaluation_periods
 
-    treat_missing_data = var.treat_missing_data
+  treat_missing_data = var.treat_missing_data
 
-    alarm_actions = var.alarm_actions
+  alarm_actions = var.alarm_actions
 }
+

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -42,7 +42,7 @@ variable "template_tags" {
 
 variable "block_device_mappings" {
   description = "EBS or other block devices to map on created instances. https://www.terraform.io/docs/providers/aws/r/launch_template.html#block-devices"
-  type        = list(string)
+  type        = list(any)
   default     = []
 }
 

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -95,6 +95,9 @@ resource "aws_launch_template" "template" {
     var.template_tags,
   )
 
+  # TF12 syntax requires using a dynamic block in order to set var.block_device_mappings
+  # to the resource's block_device_mappings, hence this complex block-in-block.
+  # This logic is used to pass through block_device_mappings unchanged.
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
     content {

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -10,7 +10,7 @@ variable "root_domain" {
 
 variable "ami_id_map" {
   description = "Mapping from role names to AMI IDs"
-  type = "map"
+  type = map
 }
 
 variable "default_ami_id" {
@@ -31,18 +31,18 @@ variable "user_data" {
 }
 
 variable "security_group_ids" {
-  type = "list"
+  type = list
 }
 
 variable "template_tags" {
   description = "Tags to apply to the launch template"
-  type = "map"
+  type = map
   default = {}
 }
 
 variable "block_device_mappings" {
   description = "EBS or other block devices to map on created instances. https://www.terraform.io/docs/providers/aws/r/launch_template.html#block-devices"
-  type = "list"
+  type = list
   default = []
 }
 

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -72,8 +72,8 @@ resource "aws_launch_template" "template" {
   tag_specifications {
     resource_type = "instance"
     tags {
-      Name = "asg-${var.env}-${var.role}",
-      prefix = "${var.role}",
+      Name = "asg-${var.env}-${var.role}"
+      prefix = "${var.role}"
       domain = "${var.env}.${var.root_domain}"
     }
   }
@@ -81,8 +81,8 @@ resource "aws_launch_template" "template" {
   tag_specifications {
     resource_type = "volume"
     tags {
-      Name = "asg-${var.env}-${var.role}",
-      prefix = "${var.role}",
+      Name = "asg-${var.env}-${var.role}"
+      prefix = "${var.role}"
       domain = "${var.env}.${var.root_domain}"
     }
   }

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -103,7 +103,7 @@ resource "aws_launch_template" "template" {
       virtual_name = lookup(block_device_mappings.value, "virtual_name", null)
 
       dynamic "ebs" {
-        for_each = lookup(block_device_mappings.value, "ebs", [])
+        for_each = flatten(list(lookup(block_device_mappings.value, "ebs", [])))
         content {
           delete_on_termination = lookup(ebs.value, "delete_on_termination", null)
           encrypted             = lookup(ebs.value, "encrypted", null)

--- a/squid_cloudwatch_filters/main.tf
+++ b/squid_cloudwatch_filters/main.tf
@@ -1,78 +1,79 @@
 variable "env_name" {
-    description = "Environment name, for prefixing the generated metric names"
+  description = "Environment name, for prefixing the generated metric names"
 }
 
 variable "log_group_name_override" {
-    default = ""
-    description = "The name of the log group, overriding the default <env_name>_/var/log/squid/access.log"
+  default     = ""
+  description = "The name of the log group, overriding the default <env_name>_/var/log/squid/access.log"
 }
 
 variable "metric_namespace" {
-    description = "Namespace to use for created cloudwatch metrics"
-    default = "LogMetrics/squid"
+  description = "Namespace to use for created cloudwatch metrics"
+  default     = "LogMetrics/squid"
 }
 
 variable "treat_missing_data" {
-    description = "How to treat missing metric data in the denials alarm. https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html#treat_missing_data"
-    default = "breaching"
+  description = "How to treat missing metric data in the denials alarm. https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html#treat_missing_data"
+  default     = "breaching"
 }
 
 variable "alarm_actions" {
-    type = list
-    description = "A list of ARNs to notify when the squid denied alarm fires"
+  type        = list(string)
+  description = "A list of ARNs to notify when the squid denied alarm fires"
 }
 
 locals {
-    log_group_name = "${var.log_group_name_override == "" ? "${var.env_name}_/var/log/squid/access.log" : var.log_group_name_override}"
+  log_group_name = var.log_group_name_override == "" ? "${var.env_name}_/var/log/squid/access.log" : var.log_group_name_override
 }
 
 resource "null_resource" "log_group_found" {
   triggers = {
-    log_group = "${local.log_group_name}"
+    log_group = local.log_group_name
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "squid_requests_total" {
-    depends_on = [null_resource.log_group_found]
-    name = "${var.env_name}-squid-requests-total"
-    pattern = "" # all events
-    log_group_name = local.log_group_name
-    metric_transformation {
-        namespace = var.metric_namespace
-        name = "${var.env_name}/TotalRequests"
-        value = 1
-        default_value = 0
-    }
+  depends_on     = [null_resource.log_group_found]
+  name           = "${var.env_name}-squid-requests-total"
+  pattern        = "" # all events
+  log_group_name = local.log_group_name
+  metric_transformation {
+    namespace     = var.metric_namespace
+    name          = "${var.env_name}/TotalRequests"
+    value         = 1
+    default_value = 0
+  }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "squid_requests_denied" {
-    depends_on = [null_resource.log_group_found]
-    name = "${var.env_name}-squid-requests-denied"
-    pattern = "\"DENIED\"" # logs containing DENIED anywhere
-    log_group_name = local.log_group_name
-    metric_transformation {
-        namespace = var.metric_namespace
-        name = "${var.env_name}/DeniedRequests"
-        value = 1
-        default_value = 0
-    }
+  depends_on     = [null_resource.log_group_found]
+  name           = "${var.env_name}-squid-requests-denied"
+  pattern        = "\"DENIED\"" # logs containing DENIED anywhere
+  log_group_name = local.log_group_name
+  metric_transformation {
+    namespace     = var.metric_namespace
+    name          = "${var.env_name}/DeniedRequests"
+    value         = 1
+    default_value = 0
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "squid_denied_alarm" {
-    alarm_name = "${var.env_name}-squid-denials"
-    alarm_description = "(Managed by Terraform) Alarm when the Squid access log shows any denied requests"
-    namespace = var.metric_namespace
-    metric_name = "${var.env_name}/DeniedRequests"
+  alarm_name        = "${var.env_name}-squid-denials"
+  alarm_description = "(Managed by Terraform) Alarm when the Squid access log shows any denied requests"
+  namespace         = var.metric_namespace
+  metric_name       = "${var.env_name}/DeniedRequests"
 
-    # alert when sum(denials) >= 1 for any 1 minute out of 15 eval periods
-    statistic = "Sum"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    threshold = 1
-    period = 60
-    datapoints_to_alarm = 1
-    evaluation_periods = 15
+  # alert when sum(denials) >= 1 for any 1 minute out of 15 eval periods
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 60
+  datapoints_to_alarm = 1
+  evaluation_periods  = 15
 
-    treat_missing_data = var.treat_missing_data
+  treat_missing_data = var.treat_missing_data
 
-    alarm_actions = var.alarm_actions
+  alarm_actions = var.alarm_actions
 }
+

--- a/squid_cloudwatch_filters/main.tf
+++ b/squid_cloudwatch_filters/main.tf
@@ -36,9 +36,9 @@ resource "aws_cloudwatch_log_metric_filter" "squid_requests_total" {
     depends_on = ["null_resource.log_group_found"]
     name = "${var.env_name}-squid-requests-total"
     pattern = "" # all events
-    log_group_name = "${local.log_group_name}"
+    log_group_name = local.log_group_name
     metric_transformation {
-        namespace = "${var.metric_namespace}"
+        namespace = var.metric_namespace
         name = "${var.env_name}/TotalRequests"
         value = 1
         default_value = 0
@@ -49,9 +49,9 @@ resource "aws_cloudwatch_log_metric_filter" "squid_requests_denied" {
     depends_on = ["null_resource.log_group_found"]
     name = "${var.env_name}-squid-requests-denied"
     pattern = "\"DENIED\"" # logs containing DENIED anywhere
-    log_group_name = "${local.log_group_name}"
+    log_group_name = local.log_group_name
     metric_transformation {
-        namespace = "${var.metric_namespace}"
+        namespace = var.metric_namespace
         name = "${var.env_name}/DeniedRequests"
         value = 1
         default_value = 0
@@ -61,7 +61,7 @@ resource "aws_cloudwatch_log_metric_filter" "squid_requests_denied" {
 resource "aws_cloudwatch_metric_alarm" "squid_denied_alarm" {
     alarm_name = "${var.env_name}-squid-denials"
     alarm_description = "(Managed by Terraform) Alarm when the Squid access log shows any denied requests"
-    namespace = "${var.metric_namespace}"
+    namespace = var.metric_namespace
     metric_name = "${var.env_name}/DeniedRequests"
 
     # alert when sum(denials) >= 1 for any 1 minute out of 15 eval periods
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "squid_denied_alarm" {
     datapoints_to_alarm = 1
     evaluation_periods = 15
 
-    treat_missing_data = "${var.treat_missing_data}"
+    treat_missing_data = var.treat_missing_data
 
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = var.alarm_actions
 }

--- a/squid_cloudwatch_filters/main.tf
+++ b/squid_cloudwatch_filters/main.tf
@@ -18,7 +18,7 @@ variable "treat_missing_data" {
 }
 
 variable "alarm_actions" {
-    type = "list"
+    type = list
     description = "A list of ARNs to notify when the squid denied alarm fires"
 }
 
@@ -33,7 +33,7 @@ resource "null_resource" "log_group_found" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "squid_requests_total" {
-    depends_on = ["null_resource.log_group_found"]
+    depends_on = [null_resource.log_group_found]
     name = "${var.env_name}-squid-requests-total"
     pattern = "" # all events
     log_group_name = local.log_group_name
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_log_metric_filter" "squid_requests_total" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "squid_requests_denied" {
-    depends_on = ["null_resource.log_group_found"]
+    depends_on = [null_resource.log_group_found]
     name = "${var.env_name}-squid-requests-denied"
     pattern = "\"DENIED\"" # logs containing DENIED anywhere
     log_group_name = local.log_group_name

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -86,7 +86,7 @@ resource "aws_s3_bucket" "s3-logs" {
 #     terraform import module.main.module.tf-state.aws_s3_bucket.tf-state login-gov.tf-state.<ACCT_ID>-<REGION>
 #
 resource "aws_s3_bucket" "tf-state" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled == 1 ? 1 : 0
 
   bucket = "login-gov.tf-state.${data.aws_caller_identity.current.account_id}-${var.region}"
   region = var.region
@@ -142,7 +142,7 @@ resource "aws_s3_bucket_public_access_block" "tf-state" {
 #     terraform import module.main.module.tf-state.aws_dynamodb_table.tf-lock-table terraform_locks
 #
 resource "aws_dynamodb_table" "tf-lock-table" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled == 1 ? 1 : 0
 
   name           = var.state_lock_table
   read_capacity  = 2

--- a/vpc_flow_cloudwatch_filters/main.tf
+++ b/vpc_flow_cloudwatch_filters/main.tf
@@ -1,88 +1,90 @@
 variable "env_name" {
-    description = "Environment name, for prefixing the generated metric names"
+  description = "Environment name, for prefixing the generated metric names"
 }
 
 variable "log_group_name_override" {
-    default = ""
-    description = "The name of the log group, overriding the default <env_name>_flow_log_group"
+  default     = ""
+  description = "The name of the log group, overriding the default <env_name>_flow_log_group"
 }
 
 variable "metric_namespace" {
-    description = "Namespace to use for created cloudwatch metrics"
-    default = "LogMetrics/vpc_flow"
+  description = "Namespace to use for created cloudwatch metrics"
+  default     = "LogMetrics/vpc_flow"
 }
 
 variable "treat_missing_data" {
-    description = "How to treat missing metric data in the rejections alarm. https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html#treat_missing_data"
-    default = "missing"
+  description = "How to treat missing metric data in the rejections alarm. https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html#treat_missing_data"
+  default     = "missing"
 }
 
 variable "alarm_actions" {
-    type = list
-    description = "A list of ARNs to notify when the VPC rejection alarm fires"
+  type        = list(string)
+  description = "A list of ARNs to notify when the VPC rejection alarm fires"
 }
 
 locals {
-    log_group_name = "${var.log_group_name_override == "" ? "${var.env_name}_flow_log_group" : var.log_group_name_override}"
+  log_group_name = var.log_group_name_override == "" ? "${var.env_name}_flow_log_group" : var.log_group_name_override
 }
 
-
 resource "aws_cloudwatch_log_metric_filter" "vpc_flow_rejections_total" {
-    name = "${var.env_name}-vpc-flow-rejections-total"
-    pattern = "[version, accountID,interfaceID, srcAddr, dstAddr, srcPort, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
-    log_group_name = local.log_group_name
-    metric_transformation {
-        namespace = var.metric_namespace
-        name = "${var.env_name}/TotalRejections"
-        value = 1
-        default_value = 0
-    }
+  name           = "${var.env_name}-vpc-flow-rejections-total"
+  pattern        = "[version, accountID,interfaceID, srcAddr, dstAddr, srcPort, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
+  log_group_name = local.log_group_name
+  metric_transformation {
+    namespace     = var.metric_namespace
+    name          = "${var.env_name}/TotalRejections"
+    value         = 1
+    default_value = 0
+  }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "vpc_flow_rejections_internal" {
-    name = "${var.env_name}-vpc-flow-rejections-internal"
-    # Same pattern as above plus srcAddr=172.16.*
-    pattern = "[version, accountID,interfaceID, srcAddr=172.16.*, dstAddr, srcPort, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
-    log_group_name = local.log_group_name
-    metric_transformation {
-        namespace = var.metric_namespace
-        name = "${var.env_name}/InternalRejections"
-        value = 1
-        default_value = 0
-    }
+  name = "${var.env_name}-vpc-flow-rejections-internal"
+
+  # Same pattern as above plus srcAddr=172.16.*
+  pattern        = "[version, accountID,interfaceID, srcAddr=172.16.*, dstAddr, srcPort, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
+  log_group_name = local.log_group_name
+  metric_transformation {
+    namespace     = var.metric_namespace
+    name          = "${var.env_name}/InternalRejections"
+    value         = 1
+    default_value = 0
+  }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "vpc_flow_rejections_unexpected" {
-    name = "${var.env_name}-vpc-flow-rejections-unexpected"
-    # Same as above plus filtering out:
-    # src port 443, 3128, and 5044 (which seem to be timed out connections)
-    # src port 26, which seems to be SSH health checks
-    # destination host 192.88.99.255 for https://console.aws.amazon.com/support/v1?region=us-west-2#/case/?displayId=5319857611&language=en
-    pattern = "[version, accountID,interfaceID, srcAddr=172.16.*, dstAddr!=192.88.99.255, srcPort!=26 && srcPort!=443 && srcPort!=3128, srcPort!=5044, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
-    log_group_name = local.log_group_name
-    metric_transformation {
-        namespace = var.metric_namespace
-        name = "${var.env_name}/UnexpectedRejections"
-        value = 1
-        default_value = 0
-    }
+  name = "${var.env_name}-vpc-flow-rejections-unexpected"
+
+  # Same as above plus filtering out:
+  # src port 443, 3128, and 5044 (which seem to be timed out connections)
+  # src port 26, which seems to be SSH health checks
+  # destination host 192.88.99.255 for https://console.aws.amazon.com/support/v1?region=us-west-2#/case/?displayId=5319857611&language=en
+  pattern        = "[version, accountID,interfaceID, srcAddr=172.16.*, dstAddr!=192.88.99.255, srcPort!=26 && srcPort!=443 && srcPort!=3128, srcPort!=5044, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
+  log_group_name = local.log_group_name
+  metric_transformation {
+    namespace     = var.metric_namespace
+    name          = "${var.env_name}/UnexpectedRejections"
+    value         = 1
+    default_value = 0
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "vpc_rejection_alarm" {
-    alarm_name = "${var.env_name}-vpc-flow-rejections-unexpected"
-    alarm_description = "(Managed by Terraform) Alarm when the VPC flow log shows any unexpected traffic"
-    namespace = var.metric_namespace
-    metric_name = "${var.env_name}/UnexpectedRejections"
+  alarm_name        = "${var.env_name}-vpc-flow-rejections-unexpected"
+  alarm_description = "(Managed by Terraform) Alarm when the VPC flow log shows any unexpected traffic"
+  namespace         = var.metric_namespace
+  metric_name       = "${var.env_name}/UnexpectedRejections"
 
-    # alert when sum(denials) >= 1 for any 1 minute out of 15 eval periods
-    statistic = "Sum"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    threshold = 1
-    period = 60
-    datapoints_to_alarm = 1
-    evaluation_periods = 15
+  # alert when sum(denials) >= 1 for any 1 minute out of 15 eval periods
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 60
+  datapoints_to_alarm = 1
+  evaluation_periods  = 15
 
-    treat_missing_data = var.treat_missing_data
+  treat_missing_data = var.treat_missing_data
 
-    alarm_actions = var.alarm_actions
+  alarm_actions = var.alarm_actions
 }
+

--- a/vpc_flow_cloudwatch_filters/main.tf
+++ b/vpc_flow_cloudwatch_filters/main.tf
@@ -18,7 +18,7 @@ variable "treat_missing_data" {
 }
 
 variable "alarm_actions" {
-    type = "list"
+    type = list
     description = "A list of ARNs to notify when the VPC rejection alarm fires"
 }
 

--- a/vpc_flow_cloudwatch_filters/main.tf
+++ b/vpc_flow_cloudwatch_filters/main.tf
@@ -30,9 +30,9 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "vpc_flow_rejections_total" {
     name = "${var.env_name}-vpc-flow-rejections-total"
     pattern = "[version, accountID,interfaceID, srcAddr, dstAddr, srcPort, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
-    log_group_name = "${local.log_group_name}"
+    log_group_name = local.log_group_name
     metric_transformation {
-        namespace = "${var.metric_namespace}"
+        namespace = var.metric_namespace
         name = "${var.env_name}/TotalRejections"
         value = 1
         default_value = 0
@@ -43,9 +43,9 @@ resource "aws_cloudwatch_log_metric_filter" "vpc_flow_rejections_internal" {
     name = "${var.env_name}-vpc-flow-rejections-internal"
     # Same pattern as above plus srcAddr=172.16.*
     pattern = "[version, accountID,interfaceID, srcAddr=172.16.*, dstAddr, srcPort, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
-    log_group_name = "${local.log_group_name}"
+    log_group_name = local.log_group_name
     metric_transformation {
-        namespace = "${var.metric_namespace}"
+        namespace = var.metric_namespace
         name = "${var.env_name}/InternalRejections"
         value = 1
         default_value = 0
@@ -59,9 +59,9 @@ resource "aws_cloudwatch_log_metric_filter" "vpc_flow_rejections_unexpected" {
     # src port 26, which seems to be SSH health checks
     # destination host 192.88.99.255 for https://console.aws.amazon.com/support/v1?region=us-west-2#/case/?displayId=5319857611&language=en
     pattern = "[version, accountID,interfaceID, srcAddr=172.16.*, dstAddr!=192.88.99.255, srcPort!=26 && srcPort!=443 && srcPort!=3128, srcPort!=5044, dstPort, protocol, packets, bytes, startTime, endTime, action=REJECT, logStatus]"
-    log_group_name = "${local.log_group_name}"
+    log_group_name = local.log_group_name
     metric_transformation {
-        namespace = "${var.metric_namespace}"
+        namespace = var.metric_namespace
         name = "${var.env_name}/UnexpectedRejections"
         value = 1
         default_value = 0
@@ -71,7 +71,7 @@ resource "aws_cloudwatch_log_metric_filter" "vpc_flow_rejections_unexpected" {
 resource "aws_cloudwatch_metric_alarm" "vpc_rejection_alarm" {
     alarm_name = "${var.env_name}-vpc-flow-rejections-unexpected"
     alarm_description = "(Managed by Terraform) Alarm when the VPC flow log shows any unexpected traffic"
-    namespace = "${var.metric_namespace}"
+    namespace = var.metric_namespace
     metric_name = "${var.env_name}/UnexpectedRejections"
 
     # alert when sum(denials) >= 1 for any 1 minute out of 15 eval periods
@@ -82,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "vpc_rejection_alarm" {
     datapoints_to_alarm = 1
     evaluation_periods = 15
 
-    treat_missing_data = "${var.treat_missing_data}"
+    treat_missing_data = var.treat_missing_data
 
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = var.alarm_actions
 }


### PR DESCRIPTION
This is an omnibus PR covering all of the style/syntax changes to the `terraform-common` templates that were necessary in order to upgrade our infrastructure to Terraform 0.12.

Due to the structure of our infrastructure, and the way that `tf-deploy` resolves all of the necessary dependencies when it calls `terraform apply`, the `terraform 0.12upgrade` tool couldn't be used within this repo. Therefore, I've manually edited files within this repo whenever issues were encountered while running `terraform` commands.