### PR TITLE
iam_assumerole: module for creating cross-account AssumeRole access via IAM

### DIFF
--- a/iam_assumerole/README.md
+++ b/iam_assumerole/README.md
@@ -2,8 +2,66 @@
 
 This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
 
-- a policy document dictating access via `statement{}` blocks
 - a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
-- a policy created from the policy document
-- an attachment of the role to the policy
+- one or more policy documents dictating access via `statement{}` blocks
+- one or more policies created from the policy document(s)
+- one or more attachments of the role to the policy(ies)
 - (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role
+
+Because Policy Documents have a size limit, it is often necessary to break policies up with multiple documents. Creating multiple policies and documents is possible using a `list(object)` variable in Terraform, which allows each object in the list to contain:
+
+1. the policy name
+2. the policy description
+3. the policy document statement(s)
+
+## Example
+
+```hcl
+locals {
+  custom_policy_arns = [
+    aws_iam_policy.rds_delete_prevent.arn,
+    aws_iam_policy.region_restriction.arn,
+  ]
+  master_assumerole_policy = data.aws_iam_policy_document.master_account_assumerole.json
+}
+
+module "billing-assumerole" {
+  source = "github.com/18F/identity-terraform//iam_assumerole?ref=master"
+
+  role_name                = "BillingReadOnly"
+  enabled                  = var.iam_billing_enabled
+  master_assumerole_policy = local.master_assumerole_policy
+  custom_policy_arns       = local.custom_policy_arns
+
+  iam_policies = [
+    {
+      policy_name        = "BillingReadOnly"
+      policy_description = "Policy for reporting group read-only access to Billing ui"
+      policy_document    = [
+        {
+          sid    = "BillingReadOnly"
+          effect = "Allow"
+          actions = [
+            "aws-portal:ViewBilling",
+          ]
+          resources = [
+            "*",
+          ]
+        },
+      ]
+    },
+  ]
+}
+```
+
+## Variables
+
+- `enabled` - **bool**: Whether or not to create the role + policy + attachments. Used when declaring a role via a Terraform template which is NOT used across all accounts. Defaults to _true_.
+- `role_name` - **string**: Name of the IAM role to be created.
+- `role_duration` - **number**: Value of the `max_session_duration` for the role, in seconds. Defaults to _43200_ (12 hours).
+- `master_assumerole_policy` - **object**: JSON object of the policy document to attach to the role allowing AssumeRole access from a master account. Pass in using `data.aws_iam_policy_document.<DATA_SOURCE_NAME>.json` as shown in the example above.
+- `custom_policy_arns` - **list**: ARNs of any additional IAM policies to attach to the role.
+- `iam_policies` - **list(object)**: List of objects, each of which contains:
+   - `policy_name` - **string**: Name of the IAM policy to be created.
+   - `policy_description` - **string**: Description of the IAM policy.
+   - `policy_document` - **list(object)**: List of Statements included in the policy document. Each _object_ in the list should include the contents of a Statement, i.e. the `sid`, `effect`, `actions`, and `resources`.

--- a/iam_assumerole/README.md
+++ b/iam_assumerole/README.md
@@ -1,0 +1,9 @@
+# `iam_assumerole`
+
+This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
+
+- a policy document dictating access via `statement{}` blocks
+- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
+- a policy created from the policy document
+- an attachment of the role to the policy
+- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role

--- a/iam_assumerole/main.tf
+++ b/iam_assumerole/main.tf
@@ -1,0 +1,95 @@
+# -- Variables --
+
+variable "enabled" {
+  description = "Whether or not to create the role/policy/attachment resources."
+  type = bool
+  default = true
+}
+
+variable "custom_policy_arns" {
+  description = "The ARNs of any additional IAM policies to attach to the role."
+  type = []
+}
+
+variable "policy_description" {
+  description = "Description of policy including access provided."
+}
+
+variable "policy_name" {
+  description = "Name of the IAM policy for the role."
+}
+
+variable "role_duration" {
+  description = "Value for the max_session_duration for the role, in seconds."
+  type = number
+  default = 43200
+}
+
+variable "role_name" {
+  description = "Name of the IAM role."
+}
+
+variable "statement" {
+  description = "Statement to add to the IAM policy document."
+  type = {}
+}
+
+# -- Resources --
+
+# create policy document; iterate through statements{} via dynamic
+data "aws_iam_policy_document" "iam_policy_doc" {
+  count = var.enabled ? 1 : 0
+
+  dynamic "statement" {
+    for_each = var.statement
+    content {
+      sid       = statement.value.sid
+      effect    = statement.value.effect
+      actions   = statement.value.actions
+      resources = statement.value.resources
+    }
+  }
+}
+
+resource "aws_iam_role" "iam_assumable_role" {
+  count = var.enabled ? 1 : 0
+
+  name                 = var.role_name
+  assume_role_policy   = data.aws_iam_policy_document.master_account_assumerole.json
+  path                 = "/"
+  max_session_duration = var.role_duration #seconds
+}
+
+resource "aws_iam_policy" "iam_role_policy" {
+  count = var.enabled ? 1 : 0
+
+  name        = var.policy_name
+  description = var.policy_description
+  policy      = data.aws_iam_policy_document.iam_policy_doc[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "policy_attachment_main" {
+  count = var.enabled ? 1 : 0
+
+  role       = aws_iam_role.iam_assumable_role[0].name
+  policy_arn = aws_iam_policy.iam_role_policy[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "policy_attachment_custom" {
+  count = var.enabled ? 1 * length(var.custom_policy_arns) : 0
+
+  role       = aws_iam_role.iam_assumable_role[0].name
+  policy_arn = element(var.custom_policy_arns, count.index)
+}
+
+# -- Outputs --
+
+output "iam_role_arn" {
+  description = "ARN of the created IAM role."
+  value = aws_iam_role.iam_assumable_role[0].arn
+}
+
+output "iam_policy_arn" {
+  description = "ARN of the created IAM policy."
+  value = aws_iam_policy.iam_role_policy[0].arn
+}

--- a/iam_assumerole/main.tf
+++ b/iam_assumerole/main.tf
@@ -16,12 +16,13 @@ variable "master_assumerole_policy" {
   description = "HEREDOC; Policy document to attach to the role allowing AssumeRole access from a master account."
 }
 
-variable "policy_description" {
-  description = "Description of policy including access provided."
-}
-
-variable "policy_name" {
-  description = "Name of the IAM policy for the role."
+variable "iam_policies" {
+  description = "Name/description/document properties for policy/policies."
+  type = list(object({
+    policy_name        = string
+    policy_description = string
+    policy_document    = list(any)
+  }))
 }
 
 variable "role_duration" {
@@ -44,10 +45,10 @@ variable "statement" {
 
 # create policy document; iterate through statements{} via dynamic
 data "aws_iam_policy_document" "iam_policy_doc" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled ? 1 * length(var.iam_policies) : 0
 
   dynamic "statement" {
-    for_each = var.statement
+    for_each = var.iam_policies[count.index].policy_document
     content {
       sid       = statement.value.sid
       effect    = statement.value.effect
@@ -55,6 +56,14 @@ data "aws_iam_policy_document" "iam_policy_doc" {
       resources = statement.value.resources
     }
   }
+}
+
+resource "aws_iam_policy" "iam_role_policy" {
+  count = var.enabled ? 1 * length(var.iam_policies) : 0
+
+  name        = var.iam_policies[count.index].policy_name
+  description = var.iam_policies[count.index].policy_description
+  policy      = data.aws_iam_policy_document.iam_policy_doc[count.index].json
 }
 
 resource "aws_iam_role" "iam_assumable_role" {
@@ -66,19 +75,11 @@ resource "aws_iam_role" "iam_assumable_role" {
   max_session_duration = var.role_duration #seconds
 }
 
-resource "aws_iam_policy" "iam_role_policy" {
-  count = var.enabled ? 1 : 0
-
-  name        = var.policy_name
-  description = var.policy_description
-  policy      = data.aws_iam_policy_document.iam_policy_doc[0].json
-}
-
 resource "aws_iam_role_policy_attachment" "policy_attachment_main" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled ? 1 * length(var.iam_policies) : 0
 
   role       = aws_iam_role.iam_assumable_role[0].name
-  policy_arn = aws_iam_policy.iam_role_policy[0].arn
+  policy_arn = aws_iam_policy.iam_role_policy[count.index].arn
 }
 
 resource "aws_iam_role_policy_attachment" "policy_attachment_custom" {
@@ -86,16 +87,4 @@ resource "aws_iam_role_policy_attachment" "policy_attachment_custom" {
 
   role       = aws_iam_role.iam_assumable_role[0].name
   policy_arn = element(var.custom_policy_arns, count.index)
-}
-
-# -- Outputs --
-
-output "iam_role_arn" {
-  description = "ARN of the created IAM role."
-  value = aws_iam_role.iam_assumable_role[0].arn
-}
-
-output "iam_policy_arn" {
-  description = "ARN of the created IAM policy."
-  value = aws_iam_policy.iam_role_policy[0].arn
 }

--- a/iam_assumerole/main.tf
+++ b/iam_assumerole/main.tf
@@ -12,6 +12,10 @@ variable "custom_policy_arns" {
   default     = []
 }
 
+variable "master_assumerole_policy" {
+  description = "HEREDOC; Policy document to attach to the role allowing AssumeRole access from a master account."
+}
+
 variable "policy_description" {
   description = "Description of policy including access provided."
 }
@@ -57,7 +61,7 @@ resource "aws_iam_role" "iam_assumable_role" {
   count = var.enabled ? 1 : 0
 
   name                 = var.role_name
-  assume_role_policy   = data.aws_iam_policy_document.master_account_assumerole.json
+  assume_role_policy   = var.master_assumerole_policy
   path                 = "/"
   max_session_duration = var.role_duration #seconds
 }

--- a/iam_assumerole/main.tf
+++ b/iam_assumerole/main.tf
@@ -8,7 +8,8 @@ variable "enabled" {
 
 variable "custom_policy_arns" {
   description = "The ARNs of any additional IAM policies to attach to the role."
-  type = []
+  type        = list(any)
+  default     = []
 }
 
 variable "policy_description" {
@@ -31,7 +32,8 @@ variable "role_name" {
 
 variable "statement" {
   description = "Statement to add to the IAM policy document."
-  type = {}
+  type        = list(any)
+  default     = []
 }
 
 # -- Resources --

--- a/iam_assumerole/main.tf
+++ b/iam_assumerole/main.tf
@@ -13,7 +13,7 @@ variable "custom_policy_arns" {
 }
 
 variable "master_assumerole_policy" {
-  description = "HEREDOC; Policy document to attach to the role allowing AssumeRole access from a master account."
+  description = "Policy document to attach to the role allowing AssumeRole access from a master account."
 }
 
 variable "iam_policies" {
@@ -33,12 +33,6 @@ variable "role_duration" {
 
 variable "role_name" {
   description = "Name of the IAM role."
-}
-
-variable "statement" {
-  description = "Statement to add to the IAM policy document."
-  type        = list(any)
-  default     = []
 }
 
 # -- Resources --


### PR DESCRIPTION
This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:

- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
- one or more policy documents dictating access via `statement{}` blocks
- one or more policies created from the policy document(s)
- one or more attachments of the role to the policy(ies)
- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role

Full information, including variable names and a working example, can be found within `iam_assumerole/README.md`. Please note that this module requires Terraform ~> 0.12 in order to work properly.