### PR TITLE
use 'enabled' flag to determine whether or not to create lambda alerts

### DIFF
--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -41,6 +41,8 @@ variable "treat_missing_data" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate" {
+  count = var.enabled
+  
   alarm_name        = "Lambda error rate: ${var.function_name}"
   alarm_description = "Lambda error rate has exceeded ${var.error_rate_threshold}%"
 

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -7,11 +7,6 @@ variable "function_name" {
   description = "Name of the lambda function to monitor"
 }
 
-# make sure that the function exists
-data "aws_lambda_function" "func" {
-  function_name = var.function_name
-}
-
 variable "alarm_actions" {
   type        = list(string)
   description = "A list of ARNs to notify when the alarm fires"
@@ -42,7 +37,7 @@ variable "treat_missing_data" {
 
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate" {
   count = var.enabled
-  
+
   alarm_name        = "Lambda error rate: ${var.function_name}"
   alarm_description = "Lambda error rate has exceeded ${var.error_rate_threshold}%"
 

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -1,3 +1,8 @@
+variable "enabled" {
+  description = "Whether or not to create the Lambda alert monitor."
+  default     = 1
+}
+
 variable "function_name" {
   description = "Name of the lambda function to monitor"
 }
@@ -35,7 +40,7 @@ variable "treat_missing_data" {
   default = "missing"
 }
 
-resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
+resource "aws_cloudwatch_metric_alarm" "lambda_error_rate" {
   alarm_name        = "Lambda error rate: ${var.function_name}"
   alarm_description = "Lambda error rate has exceeded ${var.error_rate_threshold}%"
 


### PR DESCRIPTION
The `aws_cloudwatch_metric_alarm` for Lambda error rates depends on the existence of a Lambda function; if this function does not already exist, Terraform will complain for both the CloudWatch resource and the Lambda `function_name` data source.

This PR integrates the following changes:

1. The variable `enabled` is used as a `count` conditional to determine whether or not to create the CloudWatch alarm. Defaults to 1; if set to 0, the alarm will not be created.
2. The `aws_lambda_function` data source has been removed, as it would error out if it could not get a `function_name` and does not depend on `enabled`. This data source was originally used as the conditional; it is likely that this behavior has changed in Terraform 0.12, hence why it no longer works.