### PR TITLE
moving keymaker + KMS policy doc here to eliminate terraform-plan noise

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "kms" {
       "kms:DescribeKey",
     ]
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = concat(
         var.ec2_kms_arns
       )
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "kms" {
       "*",
     ]
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = [
         "events.amazonaws.com",
         "sns.amazonaws.com",
@@ -80,7 +80,7 @@ resource "null_resource" "kms_log_found" {
 }
 
 data "aws_kms_key" "application" {
-  key_id   = aws_kms_key.login-dot-gov-keymaker.key_id
+  key_id = aws_kms_key.login-dot-gov-keymaker.key_id
 }
 
 data "aws_s3_bucket" "lambda" {

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -20,10 +20,10 @@ resource "null_resource" "kms_log_found" {
 data "aws_kms_key" "application" {
   # hack to prevent data source from being read on every apply
   # https://github.com/hashicorp/terraform/issues/11806#issuecomment-577082293
-  metadata {
-    name      = "app_key${replace(null_resource.key_found.id, "/.*/", "")}"
+  metadata = {
+    name   = "app_key${replace(null_resource.key_found.id, "/.*/", "")}"
   }
-  key_id     = "alias/${var.env_name}-login-dot-gov-keymaker"
+  key_id   = "alias/${var.env_name}-login-dot-gov-keymaker"
 }
 
 data "aws_s3_bucket" "lambda" {

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -18,7 +18,11 @@ resource "null_resource" "kms_log_found" {
 }
 
 data "aws_kms_key" "application" {
-  depends_on = [null_resource.key_found]
+  # hack to prevent data source from being read on every apply
+  # https://github.com/hashicorp/terraform/issues/11806#issuecomment-577082293
+  metadata {
+    name      = "app_key${replace(null_resource.key_found.id, "/.*/", "")}"
+  }
   key_id     = "alias/${var.env_name}-login-dot-gov-keymaker"
 }
 

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -74,6 +74,6 @@ variable "kmslog_lambda_debug" {
 }
 
 variable "ec2_kms_arns" {
-  default = []
+  default     = []
   description = "ARN(s) of EC2 roles permitted access to KMS"
 }

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -73,3 +73,7 @@ variable "kmslog_lambda_debug" {
   description = "Whether to run the kms logging lambdas in debug mode in this account"
 }
 
+variable "ec2_kms_arns" {
+  default = []
+  description = "ARN(s) of EC2 roles permitted access to KMS"
+}


### PR DESCRIPTION
In Terraform 0.11, `null_resource` blocks were used to force `data` sources to depend upon resources created by other Terraform modules. As a result of this, however, the data sources were read upon EVERY Terraform run, meaning that `terraform plan` ***always*** contained "changes" in its output (though nothing actually NEEDED to be changed).

This PR moves the resource dependencies to the `kms_log` module in this repo. After moving the state addresses and running one more `apply`, the `plan` output is now clear!