### PR TITLE
iam_assumegroup + iam_masterassume modules

### DIFF
--- a/iam_assumegroup/README.md
+++ b/iam_assumegroup/README.md
@@ -1,0 +1,67 @@
+# `iam_assumerole`
+
+This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
+
+- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
+- one or more policy documents dictating access via `statement{}` blocks
+- one or more policies created from the policy document(s)
+- one or more attachments of the role to the policy(ies)
+- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role
+
+Because Policy Documents have a size limit, it is often necessary to break policies up with multiple documents. Creating multiple policies and documents is possible using a `list(object)` variable in Terraform, which allows each object in the list to contain:
+
+1. the policy name
+2. the policy description
+3. the policy document statement(s)
+
+## Example
+
+```hcl
+locals {
+  custom_policy_arns = [
+    aws_iam_policy.rds_delete_prevent.arn,
+    aws_iam_policy.region_restriction.arn,
+  ]
+  master_assumerole_policy = data.aws_iam_policy_document.master_account_assumerole.json
+}
+
+module "billing-assumerole" {
+  source = "github.com/18F/identity-terraform//iam_assumerole?ref=master"
+
+  role_name                = "BillingReadOnly"
+  enabled                  = var.iam_billing_enabled
+  master_assumerole_policy = local.master_assumerole_policy
+  custom_policy_arns       = local.custom_policy_arns
+
+  iam_policies = [
+    {
+      policy_name        = "BillingReadOnly"
+      policy_description = "Policy for reporting group read-only access to Billing ui"
+      policy_document    = [
+        {
+          sid    = "BillingReadOnly"
+          effect = "Allow"
+          actions = [
+            "aws-portal:ViewBilling",
+          ]
+          resources = [
+            "*",
+          ]
+        },
+      ]
+    },
+  ]
+}
+```
+
+## Variables
+
+- `enabled` - **bool**: Whether or not to create the role + policy + attachments. Used when declaring a role via a Terraform template which is NOT used across all accounts. Defaults to _true_.
+- `role_name` - **string**: Name of the IAM role to be created.
+- `role_duration` - **number**: Value of the `max_session_duration` for the role, in seconds. Defaults to _43200_ (12 hours).
+- `master_assumerole_policy` - **object**: JSON object of the policy document to attach to the role allowing AssumeRole access from a master account. Pass in using `data.aws_iam_policy_document.<DATA_SOURCE_NAME>.json` as shown in the example above.
+- `custom_policy_arns` - **list**: ARNs of any additional IAM policies to attach to the role.
+- `iam_policies` - **list(object)**: List of objects, each of which contains:
+   - `policy_name` - **string**: Name of the IAM policy to be created.
+   - `policy_description` - **string**: Description of the IAM policy.
+   - `policy_document` - **list(object)**: List of Statements included in the policy document. Each _object_ in the list should include the contents of a Statement, i.e. the `sid`, `effect`, `actions`, and `resources`.

--- a/iam_assumegroup/README.md
+++ b/iam_assumegroup/README.md
@@ -1,15 +1,16 @@
-# `iam_assumerole`
+# `iam_assumegroup`
 
-This Terraform module can be used to build all necessary resources for a policy-managed IAM Group, via:
+This Terraform module can be used to create one or more IAM groups, along with attached group policies.
+The design is calculated from a map of the groups, and per-"Account Type" access levels, supplied as input.
 
-- an IAM Group resource, made up of a list of the users in the group + a custom name
-- ARN(s) for one or more Group Policies, built from a map of account types + roles per account type
-
-If Terraform is dependent upon the ARNs to be calculated outside of this module, it will be stuck in a circular dependency loop. This is why the policy ARNs are created from the input variables.
+If Terraform is dependent upon the ARNs to be calculated outside of this module,
+it will be stuck in a circular dependency loop.
+Thus, the policy ARNs are created from the input map.
 
 ## Account Type
 
-The "account type" concept allows for more granular control of permissions for IAM groups across multiple categories -- or "types" -- of AWS accounts. As an example:
+The "account type" concept allows for more granular control of permissions for IAM groups
+across multiple categories -- or "types" -- of AWS accounts. As an example:
 
 An organization has the following accounts:
 
@@ -21,9 +22,10 @@ An organization has the following accounts:
 
 Each account has the same list of roles, e.g.: FullAdmin, PowerUser, ReadOnly, SOCAdmin.
 
-Each IAM group within **Master**, created by this template, can have account-category-specific access to specific roles, e.g.:
+Each IAM group within **Master**, created by this template,
+can have account-category-specific access to specific roles, e.g.:
 
-- Developers: FullAdmin / ReadOnly / PowerUser in Dev accounts, PowerUser / ReadOnly in Prod accounts, ReadOnly in Master account
+- Developers: FullAdmin / ReadOnly / PowerUser in Dev accounts, ReadOnly in Prod accounts, ReadOnly in Master account
 - DevOps: FullAdmin in Dev accounts, FullAdmin in Prod accounts, FullAdmin in Master account
 - SOC Leads: SOCAdmin in Dev accounts, SOCAdmin in Prod accounts, FullAdmin in Master account
 
@@ -33,41 +35,38 @@ Each IAM group within **Master**, created by this template, can have account-cat
 module "devops_group" {
   source = "github.com/18F/identity-terraform//iam_assumegroup?ref=master"
   
-  group_name = "devops-team"
-  group_members = [
-    aws_iam_user.wayne.name,
-    aws_iam_user.daryl.name,
-    aws_iam_user.katie.name,
-    aws_iam_user.daniel.name,
-  ]
-  iam_group_roles = [
-    {
-      role_name = "FullAdministrator",
-      account_types = [ 
-        "Prod", "Sandbox", "Master"
-      ]
-    },
-    {
-      role_name = "ReadOnly",
-      account_types = [ 
-        "Prod", "Sandbox"
-      ]
-    },
-    {
-      role_name = "KMSAdmin",
-      account_types = [ 
-        "Sandbox"
-      ]
-    }
-  ]
-  master_account_id = var.master_account_id
-}
+  group_role_map = {
+    "appdev" = [
+      { "PowerUser"         = [ "Sandbox" ] },
+      { "ReadOnly"          = [ "Sandbox" ] }
+    ],
+    "devops" = [
+      { "FullAdministrator" = [ "Prod", "Sandbox", "Master" ] },
+      { "ReadOnly"          = [ "Prod", "Sandbox" ] },
+      { "KMSAdministrator"  = [ "Sandbox" ] }
+    ],
+    "soc" = [
+      { "SOCAdministrator"  = [ "Sandbox", "Prod", "Master" ] }
+    ]
+  }
 
+  master_account_id = "111122223333"
+}
 ```
 
 ## Variables
 
-`group_name` - Name of the group to be created.
 `master_account_id` - AWS account ID for the 'master' account, where this group and all IAM users live.
-`group_members` - List of AWS IAM users to be added to the group.
-`iam_group_roles` - Map of roles / account types the group has access to, where each key:value pair is `role_name`:`account_types` (string:list).
+`group_role_map` - Multi-level map of groups -> roles -> accounts, with each *element* being a map of the format below:
+
+```
+{
+  "GROUP" = [
+    {
+      "ROLE" = [
+        "ACCOUNT_TYPE"
+      ]
+    }
+  ]
+}
+```

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -45,7 +45,7 @@ resource "aws_iam_group_membership" "iam_group_members" {
 
 resource "aws_iam_group_policy_attachment" "iam_group_policies" {
   for_each = {
-    for role_name in local.account_roles: lower(role_name) => role_name
+    for role_name in local.account_roles: role_name => role_name
   }
   
   group = var.group_name

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -16,6 +16,11 @@ variable "group_name" {
   description = "Name of the IAM group."
 }
 
+variable "module_depends_on" {
+  type    = any
+  default = null
+}
+
 # -- Resources --
 
 resource "aws_iam_group" "iam_group" {
@@ -29,8 +34,9 @@ resource "aws_iam_group_membership" "iam_group_members" {
 }
 
 resource "aws_iam_group_policy_attachment" "iam_group_policies" {
-  for_each = var.assume_role_policy_arns
-
+  depends_on = [var.module_depends_on]
+  for_each = toset(var.assume_role_policy_arns)
+  
   group = var.group_name
   policy_arn = each.key
 }

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -10,18 +10,15 @@ variable "group_role_map" {
 }
 
 locals {
-  group_account_map = [
-    for line in flatten([
-      for item, access in
-      {
-        for group, perms in var.group_role_map : group => flatten([
-          for perm in perms: flatten([
-            for pair in setproduct(keys(perm), flatten([values(perm)])): join("", [pair[1], "Assume", pair[0]])
-          ])
+  role_group_map = transpose(
+    {
+      for group, perms in var.group_role_map : group => flatten([
+        for perm in perms: flatten([
+          for pair in setproduct(keys(perm), flatten([values(perm)])): join("", [pair[1], "Assume", pair[0]])
         ])
-      }: formatlist("%s %s", item, access)
-    ]): split(" ", line)
-  ]
+      ])
+    }
+  )
 }
 
 # -- Resources --
@@ -32,9 +29,11 @@ resource "aws_iam_group" "iam_group" {
   name = each.key
 }
 
-resource "aws_iam_group_policy_attachment" "iam_group_policies" {
-  count = length(local.group_account_map)
+resource "aws_iam_policy_attachment" "group_policy" {
+  for_each = local.role_group_map
   
-  group = element(local.group_account_map[count.index],0)
-  policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${element(local.group_account_map[count.index],1)}"
+  name       = each.key
+  groups     = each.value
+  policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${each.key}"
 }
+

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -22,8 +22,8 @@ resource "aws_iam_group" "iam_group" {
   name = var.group_name
 }
 
-resource "aws_iam_group_membership" "keymasters_members" {
-  name = "keymasters_members"
+resource "aws_iam_group_membership" "iam_group_members" {
+  name = "${var.group_name}_members"
   users = var.group_members
   group = var.group_name
 }

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -1,0 +1,36 @@
+# -- Variables --
+
+variable "assume_role_policy_arns" {
+  description = "The ARNs of IAM policies to attach to the group."
+  type        = list(any)
+  default     = []
+}
+
+variable "group_members" {
+  description = "AWS usernames of members within the group."
+  type        = list(any)
+  default     = []
+}
+
+variable "group_name" {
+  description = "Name of the IAM group."
+}
+
+# -- Resources --
+
+resource "aws_iam_group" "iam_group" {
+  name = var.group_name
+}
+
+resource "aws_iam_group_membership" "keymasters_members" {
+  name = "keymasters_members"
+  users = var.group_members
+  group = var.group_name
+}
+
+resource "aws_iam_group_policy_attachment" "iam_group_policies" {
+  for_each = var.assume_role_policy_arns
+
+  group = var.group_name
+  policy_arn = each.key
+}

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -44,8 +44,10 @@ resource "aws_iam_group_membership" "iam_group_members" {
 }
 
 resource "aws_iam_group_policy_attachment" "iam_group_policies" {
-  count = length(local.account_roles)
+  for_each = {
+    for role_name in local.account_roles: lower(role_name) => role_name
+  }
   
   group = var.group_name
-  policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${local.account_roles[count.index]}"
+  policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${each.value}"
 }

--- a/iam_masterassume/README.md
+++ b/iam_masterassume/README.md
@@ -1,4 +1,4 @@
-# `iam_assumerole`
+# `iam_masterassume`
 
 This Terraform module creates IAM policies, and associated policy documents, allowing groups/users in a 'master' AWS account to assume roles in other accounts.
 

--- a/iam_masterassume/README.md
+++ b/iam_masterassume/README.md
@@ -1,0 +1,67 @@
+# `iam_assumerole`
+
+This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
+
+- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
+- one or more policy documents dictating access via `statement{}` blocks
+- one or more policies created from the policy document(s)
+- one or more attachments of the role to the policy(ies)
+- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role
+
+Because Policy Documents have a size limit, it is often necessary to break policies up with multiple documents. Creating multiple policies and documents is possible using a `list(object)` variable in Terraform, which allows each object in the list to contain:
+
+1. the policy name
+2. the policy description
+3. the policy document statement(s)
+
+## Example
+
+```hcl
+locals {
+  custom_policy_arns = [
+    aws_iam_policy.rds_delete_prevent.arn,
+    aws_iam_policy.region_restriction.arn,
+  ]
+  master_assumerole_policy = data.aws_iam_policy_document.master_account_assumerole.json
+}
+
+module "billing-assumerole" {
+  source = "github.com/18F/identity-terraform//iam_assumerole?ref=master"
+
+  role_name                = "BillingReadOnly"
+  enabled                  = var.iam_billing_enabled
+  master_assumerole_policy = local.master_assumerole_policy
+  custom_policy_arns       = local.custom_policy_arns
+
+  iam_policies = [
+    {
+      policy_name        = "BillingReadOnly"
+      policy_description = "Policy for reporting group read-only access to Billing ui"
+      policy_document    = [
+        {
+          sid    = "BillingReadOnly"
+          effect = "Allow"
+          actions = [
+            "aws-portal:ViewBilling",
+          ]
+          resources = [
+            "*",
+          ]
+        },
+      ]
+    },
+  ]
+}
+```
+
+## Variables
+
+- `enabled` - **bool**: Whether or not to create the role + policy + attachments. Used when declaring a role via a Terraform template which is NOT used across all accounts. Defaults to _true_.
+- `role_name` - **string**: Name of the IAM role to be created.
+- `role_duration` - **number**: Value of the `max_session_duration` for the role, in seconds. Defaults to _43200_ (12 hours).
+- `master_assumerole_policy` - **object**: JSON object of the policy document to attach to the role allowing AssumeRole access from a master account. Pass in using `data.aws_iam_policy_document.<DATA_SOURCE_NAME>.json` as shown in the example above.
+- `custom_policy_arns` - **list**: ARNs of any additional IAM policies to attach to the role.
+- `iam_policies` - **list(object)**: List of objects, each of which contains:
+   - `policy_name` - **string**: Name of the IAM policy to be created.
+   - `policy_description` - **string**: Description of the IAM policy.
+   - `policy_document` - **list(object)**: List of Statements included in the policy document. Each _object_ in the list should include the contents of a Statement, i.e. the `sid`, `effect`, `actions`, and `resources`.

--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -1,0 +1,34 @@
+# -- Variables --
+
+variable "account_numbers" {
+  description = "List of AWS account numbers where this policy can access the specified Assumable role"
+  type = list(any)
+}
+
+variable "role_type" {
+  description = "Type/name of the Assumable role. Should correspond to an actual role name in the account(s) listed."
+}
+
+variable "account_type" {
+  description = "Type/name that the listed account(s) fall under (e.g. prod, dev, etc.)"
+}
+
+# -- Resources --
+
+resource "aws_iam_policy" "role_type_policy" {
+  name        = join("", [title(var.account_type), "Assume", title(var.role_type)]))
+  path        = "/"
+  description = "Policy to allow user to assume ${var.role_type} role in ${var.account_type}."
+  policy      = data.aws_iam_policy_document.role_type_policy.json
+}
+
+data "aws_iam_policy_document" "role_type_policy" {
+  statement {
+    sid    = join("", [title(var.account_type), "Assume", title(var.role_type)]))
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = formatlist("arn:aws:iam::%s:role/${var.role_type}",var.account_numbers)
+  }
+}

--- a/iam_masterusers/README.md
+++ b/iam_masterusers/README.md
@@ -1,0 +1,23 @@
+# `iam_masteruser`
+
+This Terraform module can be used to create one or more IAM users.
+Group memberships are assigned per-user for simpler user management.
+
+## Example
+
+```hcl
+module "our_cool_master_users" {
+  source = "github.com/18F/identity-terraform//iam_masterusers?ref=master"
+  
+  user_map = {
+    'fred.flinstone' = ['development'],
+    'barny.rubble' = ['devops'],
+    'space.ghost' = ['devops', 'host'],
+  }
+}
+```
+
+## Variables
+
+`user_map` - Map with user name as key and a list of group memberships
+             as the value.

--- a/iam_masterusers/README.md
+++ b/iam_masterusers/README.md
@@ -3,6 +3,16 @@
 This Terraform module can be used to create one or more IAM users.
 Group memberships are assigned per-user for simpler user management.
 
+By default, an IAM policy called ***ManageYourAccount*** will also be created,
+which is attached to all users in `user_map`. It allows each user
+basic access to configure their own account, i.e. updating their own
+password, adding an MFA device, etc., and sets an explicit **Deny** on
+numerous actions -- *including* `sts:AssumeRole` -- if the user does
+not have an MFA device configured.
+
+The creation of this IAM policy can be disabled by setting the variable
+`allow_self_management` to **false**.
+
 ## Example
 
 ```hcl
@@ -19,5 +29,7 @@ module "our_cool_master_users" {
 
 ## Variables
 
-`user_map` - Map with user name as key and a list of group memberships
-             as the value.
+`user_map` - Map with user name as key and a list of group memberships as the value.
+`allow_self_management` - Whether or not to create the 'ManageYourAccount' IAM policy
+and attach it to all users in var.user_map in this account.
+

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -1,3 +1,5 @@
+# -- Variables --
+
 variable "user_map" {
   description = "Map of users to group memberships."
   type        = map(list(string))

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -5,6 +5,14 @@ variable "user_map" {
   type        = map(list(string))
 }
 
+variable "allow_self_management" {
+  description = <<EOM
+Whether or not to create the 'ManageYourAccount' IAM policy and
+attach it to all users in var.user_map in this account.
+EOM
+  type        = bool
+  default     = true
+}
 
 # -- Resources --
 
@@ -15,9 +23,172 @@ resource "aws_iam_user" "master_user" {
   force_destroy = true
 }
 
-resource "aws_iam_user_group_membership" "master_user" {
-  for_each = var.user_map
+resource "aws_iam_group_membership" "master_group" {
+  for_each = transpose(var.user_map)
 
-  user = each.key
-  groups = each.value
+  name = "${each.key}-group"
+  group = each.key
+  users = each.value
+}
+
+resource "aws_iam_policy" "manage_your_account" {
+  count = var.allow_self_management ? 1 : 0
+
+  name        = "ManageYourAccount"
+  path        = "/"
+  description = "Policy for account self management"
+  policy      = data.aws_iam_policy_document.manage_your_account.json
+}
+
+resource "aws_iam_policy_attachment" "manage_your_account" {
+  count = var.allow_self_management ? 1 : 0
+
+  name = "ManageYourAccount"
+  users = keys(var.user_map)
+  policy_arn = aws_iam_policy.manage_your_account[0].arn
+}
+
+data "aws_iam_policy_document" "manage_your_account" {
+  statement {
+    sid    = "AllowAllUsersToListAccounts"
+    effect = "Allow"
+    actions = [
+      "iam:ListAccountAliases",
+      "iam:ListUsers",
+      "iam:ListVirtualMFADevices",
+      "iam:GetAccountPasswordPolicy",
+      "iam:GetAccountSummary",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+  statement {
+    sid    = "AllowAllUsersToListIAMResourcesWithMFA"
+    effect = "Allow"
+    actions = [
+      "iam:ListPolicies",
+      "iam:GetPolicyVersion",
+    ]
+    resources = [
+      "*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values = [
+        "true",
+      ]
+    }
+  }
+  statement {
+    sid    = "AllowIndividualUserToSeeAndManageOnlyTheirOwnAccountInformation"
+    effect = "Allow"
+    actions = [
+      "iam:ChangePassword",
+      "iam:CreateAccessKey",
+      "iam:CreateLoginProfile",
+      "iam:DeleteAccessKey",
+      "iam:DeleteLoginProfile",
+      "iam:GetLoginProfile",
+      "iam:GetUser",
+      "iam:GetAccessKeyLastUsed",
+      "iam:ListAccessKeys",
+      "iam:UpdateAccessKey",
+      "iam:UpdateLoginProfile",
+      "iam:ListSigningCertificates",
+      "iam:DeleteSigningCertificate",
+      "iam:UpdateSigningCertificate",
+      "iam:UploadSigningCertificate",
+      "iam:ListSSHPublicKeys",
+      "iam:GetSSHPublicKey",
+      "iam:DeleteSSHPublicKey",
+      "iam:UpdateSSHPublicKey",
+      "iam:UploadSSHPublicKey",
+      "iam:ListUserPolicies",
+      "iam:ListAttachedUserPolicies",
+      "iam:ListGroupsForUser",
+    ]
+    resources = [
+      "arn:aws:iam::*:user/$${aws:username}",
+    ]
+  }
+  statement {
+    sid    = "AllowIndividualUserToListOnlyTheirOwnMFA"
+    effect = "Allow"
+    actions = [
+      "iam:ListMFADevices",
+    ]
+    resources = [
+      "arn:aws:iam::*:mfa/*",
+      "arn:aws:iam::*:user/$${aws:username}",
+    ]
+  }
+  statement {
+    sid    = "AllowIndividualUserToManageTheirOwnMFA"
+    effect = "Allow"
+    actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:DeleteVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ResyncMFADevice",
+    ]
+    resources = [
+      "arn:aws:iam::*:mfa/$${aws:username}",
+      "arn:aws:iam::*:user/$${aws:username}",
+    ]
+  }
+  statement {
+    sid    = "AllowIndividualUserToDeactivateOnlyTheirOwnMFAOnlyWhenUsingMFA"
+    effect = "Allow"
+    actions = [
+      "iam:DeactivateMFADevice",
+    ]
+    resources = [
+      "arn:aws:iam::*:mfa/$${aws:username}",
+      "arn:aws:iam::*:user/$${aws:username}",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values = [
+        "true",
+      ]
+    }
+  }
+  statement {
+    sid    = "BlockMostAccessUnlessSignedInWithMFA"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteVirtualMFADevice",
+      "iam:DeleteLoginProfile",
+      "iam:DeleteAccessKey",
+      "iam:DeactivateMFADevice",
+      "iam:ResyncMFADevice",
+      "iam:ListSSHPublicKeys",
+      "iam:DeleteSSHPublicKey",
+      "iam:UpdateSSHPublicKey",
+      "iam:UploadSSHPublicKey",
+      "iam:ListAccessKeys",
+      "iam:GetAccessKeyLastUsed",
+      "iam:ListServiceSpecificCredentials",
+      "iam:GetAccountSummary",
+      "iam:GetUser",
+      "iam:ListUserPolicies",
+      "iam:ListAttachedUserPolicies",
+      "iam:ListGroupsForUser",
+      "iam:GetPolicyVersion",
+      "sts:AssumeRole",
+    ]
+    resources = [
+      "*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values = [
+        "false",
+      ]
+    }
+  }
 }

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -1,0 +1,21 @@
+variable "user_map" {
+  description = "Map of users to group memberships."
+  type        = map(list(string))
+}
+
+
+# -- Resources --
+
+resource "aws_iam_user" "master_user" {
+  for_each = var.user_map
+
+  name          = each.key
+  force_destroy = true
+}
+
+resource "aws_iam_user_group_membership" "master_user" {
+  for_each = var.user_map
+
+  user = each.key
+  groups = each.value
+}


### PR DESCRIPTION
## Overview

This PR creates two new Terraform modules, `iam_assumegroup` and `iam_masterassume modules`, which can be respectively used to:

1. Create an AWS IAM Group, with a specified list of users and generated ARNs for per-account-type Assume-Role-access IAM policies
2. Create an IAM policy(ies) for assuming access to specific roles within a category of AWS accounts

## Account Type

The "account type" concept allows for more granular control of permissions for IAM groups across multiple categories -- or "types" -- of AWS accounts. As an example:

An organization has the following accounts:

1. Dev / Infrastructure
2. Dev / S3 Buckets
3. Prod / Infrastructure
4. Prod / S3 Buckets
5. Master

Each account has the same list of roles, e.g.: FullAdmin, PowerUser, ReadOnly, SOCAdmin.

1. 3 AWS accounts for development
2. 2 accounts for production
3. 1 account for 'master'

### `iam_assumegroup`

Builds all necessary resources for a policy-managed IAM Group, via:

- an IAM Group resource, made up of a list of the users in the group + a custom name
- ARN(s) for one or more Group Policies, built from a map of account types + roles per account type

If Terraform is dependent upon the ARNs to be calculated outside of this module, it will be stuck in a circular dependency loop. This is why the policy ARNs are created from the input variables.

Each IAM group within **Master**, created by this template, can have account-category-specific access to specific roles, e.g.:

- Developers: FullAdmin / ReadOnly / PowerUser in Dev accounts, PowerUser / ReadOnly in Prod accounts, ReadOnly in Master account
- DevOps: FullAdmin in Dev accounts, FullAdmin in Prod accounts, FullAdmin in Master account
- SOC Leads: SOCAdmin in Dev accounts, SOCAdmin in Prod accounts, FullAdmin in Master account

### `iam_masterassume`

This Terraform module creates IAM policies, and associated policy documents, allowing groups/users in a 'master' AWS account to assume roles in other accounts.

A module can be added to the Terraform configuration for each "type" of account, which will create all necessary IAM policies (and documents) to allow AssumeRole access for each Role to all accounts within that "type".