### PR TITLE
module "ses_dkim_r53" : SES domain identity management

### DIFF
--- a/ses_dkim_r53/README.md
+++ b/ses_dkim_r53/README.md
@@ -1,0 +1,67 @@
+# `iam_assumerole`
+
+This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
+
+- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
+- one or more policy documents dictating access via `statement{}` blocks
+- one or more policies created from the policy document(s)
+- one or more attachments of the role to the policy(ies)
+- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role
+
+Because Policy Documents have a size limit, it is often necessary to break policies up with multiple documents. Creating multiple policies and documents is possible using a `list(object)` variable in Terraform, which allows each object in the list to contain:
+
+1. the policy name
+2. the policy description
+3. the policy document statement(s)
+
+## Example
+
+```hcl
+locals {
+  custom_policy_arns = [
+    aws_iam_policy.rds_delete_prevent.arn,
+    aws_iam_policy.region_restriction.arn,
+  ]
+  master_assumerole_policy = data.aws_iam_policy_document.master_account_assumerole.json
+}
+
+module "billing-assumerole" {
+  source = "github.com/18F/identity-terraform//iam_assumerole?ref=master"
+
+  role_name                = "BillingReadOnly"
+  enabled                  = var.iam_billing_enabled
+  master_assumerole_policy = local.master_assumerole_policy
+  custom_policy_arns       = local.custom_policy_arns
+
+  iam_policies = [
+    {
+      policy_name        = "BillingReadOnly"
+      policy_description = "Policy for reporting group read-only access to Billing ui"
+      policy_document    = [
+        {
+          sid    = "BillingReadOnly"
+          effect = "Allow"
+          actions = [
+            "aws-portal:ViewBilling",
+          ]
+          resources = [
+            "*",
+          ]
+        },
+      ]
+    },
+  ]
+}
+```
+
+## Variables
+
+- `enabled` - **bool**: Whether or not to create the role + policy + attachments. Used when declaring a role via a Terraform template which is NOT used across all accounts. Defaults to _true_.
+- `role_name` - **string**: Name of the IAM role to be created.
+- `role_duration` - **number**: Value of the `max_session_duration` for the role, in seconds. Defaults to _43200_ (12 hours).
+- `master_assumerole_policy` - **object**: JSON object of the policy document to attach to the role allowing AssumeRole access from a master account. Pass in using `data.aws_iam_policy_document.<DATA_SOURCE_NAME>.json` as shown in the example above.
+- `custom_policy_arns` - **list**: ARNs of any additional IAM policies to attach to the role.
+- `iam_policies` - **list(object)**: List of objects, each of which contains:
+   - `policy_name` - **string**: Name of the IAM policy to be created.
+   - `policy_description` - **string**: Description of the IAM policy.
+   - `policy_document` - **list(object)**: List of Statements included in the policy document. Each _object_ in the list should include the contents of a Statement, i.e. the `sid`, `effect`, `actions`, and `resources`.

--- a/ses_dkim_r53/README.md
+++ b/ses_dkim_r53/README.md
@@ -1,67 +1,26 @@
-# `iam_assumerole`
+# `ses_dkim_r53`
 
-This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
+Given a domain name and a Route53 zone ID, this Terraform module will create:
 
-- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
-- one or more policy documents dictating access via `statement{}` blocks
-- one or more policies created from the policy document(s)
-- one or more attachments of the role to the policy(ies)
-- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role
-
-Because Policy Documents have a size limit, it is often necessary to break policies up with multiple documents. Creating multiple policies and documents is possible using a `list(object)` variable in Terraform, which allows each object in the list to contain:
-
-1. the policy name
-2. the policy description
-3. the policy document statement(s)
+- an SES identity resource for the provided domain + corresponding Route53 TXT verification record
+- three (3) SES domain DKIM generation resources for the provided domain + corresponding Route53 CNAME records
 
 ## Example
 
 ```hcl
-locals {
-  custom_policy_arns = [
-    aws_iam_policy.rds_delete_prevent.arn,
-    aws_iam_policy.region_restriction.arn,
-  ]
-  master_assumerole_policy = data.aws_iam_policy_document.master_account_assumerole.json
-}
+module "core_ses" {
+  source = "github.com/18F/identity-terraform//ses_dkim_r53?ref=master"
 
-module "billing-assumerole" {
-  source = "github.com/18F/identity-terraform//iam_assumerole?ref=master"
-
-  role_name                = "BillingReadOnly"
-  enabled                  = var.iam_billing_enabled
-  master_assumerole_policy = local.master_assumerole_policy
-  custom_policy_arns       = local.custom_policy_arns
-
-  iam_policies = [
-    {
-      policy_name        = "BillingReadOnly"
-      policy_description = "Policy for reporting group read-only access to Billing ui"
-      policy_document    = [
-        {
-          sid    = "BillingReadOnly"
-          effect = "Allow"
-          actions = [
-            "aws-portal:ViewBilling",
-          ]
-          resources = [
-            "*",
-          ]
-        },
-      ]
-    },
-  ]
+  domain                    = var.root_domain
+  zone_id                   = module.common_dns.primary_zone_id
+  ttl_verification_record   = "1800"
+  ttl_dkim_records          = "1800"
 }
 ```
 
 ## Variables
 
-- `enabled` - **bool**: Whether or not to create the role + policy + attachments. Used when declaring a role via a Terraform template which is NOT used across all accounts. Defaults to _true_.
-- `role_name` - **string**: Name of the IAM role to be created.
-- `role_duration` - **number**: Value of the `max_session_duration` for the role, in seconds. Defaults to _43200_ (12 hours).
-- `master_assumerole_policy` - **object**: JSON object of the policy document to attach to the role allowing AssumeRole access from a master account. Pass in using `data.aws_iam_policy_document.<DATA_SOURCE_NAME>.json` as shown in the example above.
-- `custom_policy_arns` - **list**: ARNs of any additional IAM policies to attach to the role.
-- `iam_policies` - **list(object)**: List of objects, each of which contains:
-   - `policy_name` - **string**: Name of the IAM policy to be created.
-   - `policy_description` - **string**: Description of the IAM policy.
-   - `policy_document` - **list(object)**: List of Statements included in the policy document. Each _object_ in the list should include the contents of a Statement, i.e. the `sid`, `effect`, `actions`, and `resources`.
+- `domain` - Name of the owned/managed domain.
+- `zone_id` - ID for the Route53 zone where the domain exists.
+- `ttl_verification_record` - TTL value for the SES verification TXT record. Defaults to ***1800***.
+- `ttl_dkim_records` - TTL value for the SES DKIM records. Defaults to ***1800***.

--- a/ses_dkim_r53/main.tf
+++ b/ses_dkim_r53/main.tf
@@ -24,6 +24,15 @@ variable "ttl_dkim_records" {
   default     = "1800"
 }
 
+variable "create_token" {
+  description = <<EOM
+Whether or not to create a primary_verification_record in Route53.
+Set to FALSE if this TXT record has been created with multiple entries.
+EOM
+  type        = bool
+  default     = true
+}
+
 # -- Resources --
 
 resource "aws_ses_domain_identity" "primary" {
@@ -35,6 +44,7 @@ resource "aws_ses_domain_dkim" "primary" {
 }
 
 resource "aws_route53_record" "primary_verification_record" {
+  count   = var.create_token ? 1 : 0
   zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
   type    = "TXT"

--- a/ses_dkim_r53/main.tf
+++ b/ses_dkim_r53/main.tf
@@ -57,8 +57,8 @@ resource "aws_route53_record" "primary_verification_record" {
 resource "aws_route53_record" "primary_ses_dkim" {
   count   = 3
   zone_id = var.zone_id
-  name    = "${var.manual_dkim_tokens != "" ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  name    = "${length(var.manual_dkim_tokens) > 0 ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
   ttl     = var.ttl_dkim_records
-  records = ["${var.manual_dkim_tokens != "" ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  records = ["${length(var.manual_dkim_tokens) > 0 ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }

--- a/ses_dkim_r53/main.tf
+++ b/ses_dkim_r53/main.tf
@@ -43,7 +43,7 @@ resource "aws_ses_domain_identity" "primary" {
 }
 
 resource "aws_ses_domain_dkim" "primary" {
-  domain = "${aws_ses_domain_identity.primary.domain}"
+  domain = aws_ses_domain_identity.primary.domain
 }
 
 resource "aws_route53_record" "primary_verification_record" {
@@ -57,8 +57,8 @@ resource "aws_route53_record" "primary_verification_record" {
 resource "aws_route53_record" "primary_ses_dkim" {
   count   = 3
   zone_id = var.zone_id
-  name    = "${element(var.manual_dkim_tokens != "" ? var.manual_dkim_tokens : aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  name    = "${var.manual_dkim_tokens != "" ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
   ttl     = var.ttl_dkim_records
-  records = ["${element(var.manual_dkim_tokens != "" ? var.manual_dkim_tokens : aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  records = ["${var.manual_dkim_tokens != "" ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }

--- a/ses_dkim_r53/main.tf
+++ b/ses_dkim_r53/main.tf
@@ -1,0 +1,64 @@
+# -- Variables --
+
+variable "domain" {
+  description = "Name of the owned/managed domain."
+  type        = string
+  default     = "example.com"
+}
+
+variable "zone_id" {
+  description = "ID for the Route53 zone where the domain exists."
+  type        = string
+  default     = "ABCDEFGHIJ123"
+}
+
+variable "manual_verification_token" {
+  description = "SES verification token, if previously created outside of Terraform"
+  type        = string
+  default     = ""
+}
+
+variable "manual_dkim_tokens" {
+  description = "SES DKIM tokens, if previously created outside of Terraform"
+  type        = list(any)
+  default     = []
+}
+
+variable "ttl_verification_record" {
+  description = "TTL value for the SES verification TXT record."
+  type        = string
+  default     = "1800"
+}
+
+variable "ttl_dkim_records" {
+  description = "TTL value for the SES DKIM records."
+  type        = string
+  default     = "1800"
+}
+
+# -- Resources --
+
+resource "aws_ses_domain_identity" "primary" {
+  domain = var.domain
+}
+
+resource "aws_ses_domain_dkim" "primary" {
+  domain = "${aws_ses_domain_identity.primary.domain}"
+}
+
+resource "aws_route53_record" "primary_verification_record" {
+  zone_id = var.zone_id
+  name    = "_amazonses.${var.domain}"
+  type    = "TXT"
+  ttl     = var.ttl_verification_record
+  records = ["${var.manual_verification_token != "" ? var.manual_verification_token : aws_ses_domain_identity.example.verification_token}"]
+}
+
+resource "aws_route53_record" "primary_ses_dkim" {
+  count   = 3
+  zone_id = var.zone_id
+  name    = "${element(var.manual_dkim_tokens != "" ? var.manual_dkim_tokens : aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  type    = "CNAME"
+  ttl     = var.ttl_dkim_records
+  records = ["${element(var.manual_dkim_tokens != "" ? var.manual_dkim_tokens : aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}

--- a/ses_dkim_r53/main.tf
+++ b/ses_dkim_r53/main.tf
@@ -51,7 +51,7 @@ resource "aws_route53_record" "primary_verification_record" {
   name    = "_amazonses.${var.domain}"
   type    = "TXT"
   ttl     = var.ttl_verification_record
-  records = ["${var.manual_verification_token != "" ? var.manual_verification_token : aws_ses_domain_identity.example.verification_token}"]
+  records = ["${var.manual_verification_token != "" ? var.manual_verification_token : aws_ses_domain_identity.primary.verification_token}"]
 }
 
 resource "aws_route53_record" "primary_ses_dkim" {

--- a/ses_dkim_r53/main.tf
+++ b/ses_dkim_r53/main.tf
@@ -12,18 +12,6 @@ variable "zone_id" {
   default     = "ABCDEFGHIJ123"
 }
 
-variable "manual_verification_token" {
-  description = "SES verification token, if previously created outside of Terraform"
-  type        = string
-  default     = ""
-}
-
-variable "manual_dkim_tokens" {
-  description = "SES DKIM tokens, if previously created outside of Terraform"
-  type        = list(any)
-  default     = []
-}
-
 variable "ttl_verification_record" {
   description = "TTL value for the SES verification TXT record."
   type        = string
@@ -51,14 +39,14 @@ resource "aws_route53_record" "primary_verification_record" {
   name    = "_amazonses.${var.domain}"
   type    = "TXT"
   ttl     = var.ttl_verification_record
-  records = ["${var.manual_verification_token != "" ? var.manual_verification_token : aws_ses_domain_identity.primary.verification_token}"]
+  records = ["${aws_ses_domain_identity.primary.verification_token}"]
 }
 
 resource "aws_route53_record" "primary_ses_dkim" {
   count   = 3
   zone_id = var.zone_id
-  name    = "${length(var.manual_dkim_tokens) > 0 ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  name    = "${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
   ttl     = var.ttl_dkim_records
-  records = ["${length(var.manual_dkim_tokens) > 0 ? var.manual_dkim_tokens[count.index] : element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  records = ["${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }


### PR DESCRIPTION
## Overview

Given a domain name and a Route53 zone ID, this Terraform module will create:

- an SES identity resource for the provided domain + corresponding Route53 TXT verification record
- three (3) SES domain DKIM generation resources for the provided domain + corresponding Route53 CNAME records

Additional information provided in the associated `README.md` file.