### PR TITLE
WIP - IAM refactor with account type map and users map

### DIFF
--- a/iam_assumegroup/README.md
+++ b/iam_assumegroup/README.md
@@ -1,0 +1,67 @@
+# `iam_assumerole`
+
+This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
+
+- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
+- one or more policy documents dictating access via `statement{}` blocks
+- one or more policies created from the policy document(s)
+- one or more attachments of the role to the policy(ies)
+- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role
+
+Because Policy Documents have a size limit, it is often necessary to break policies up with multiple documents. Creating multiple policies and documents is possible using a `list(object)` variable in Terraform, which allows each object in the list to contain:
+
+1. the policy name
+2. the policy description
+3. the policy document statement(s)
+
+## Example
+
+```hcl
+locals {
+  custom_policy_arns = [
+    aws_iam_policy.rds_delete_prevent.arn,
+    aws_iam_policy.region_restriction.arn,
+  ]
+  master_assumerole_policy = data.aws_iam_policy_document.master_account_assumerole.json
+}
+
+module "billing-assumerole" {
+  source = "github.com/18F/identity-terraform//iam_assumerole?ref=master"
+
+  role_name                = "BillingReadOnly"
+  enabled                  = var.iam_billing_enabled
+  master_assumerole_policy = local.master_assumerole_policy
+  custom_policy_arns       = local.custom_policy_arns
+
+  iam_policies = [
+    {
+      policy_name        = "BillingReadOnly"
+      policy_description = "Policy for reporting group read-only access to Billing ui"
+      policy_document    = [
+        {
+          sid    = "BillingReadOnly"
+          effect = "Allow"
+          actions = [
+            "aws-portal:ViewBilling",
+          ]
+          resources = [
+            "*",
+          ]
+        },
+      ]
+    },
+  ]
+}
+```
+
+## Variables
+
+- `enabled` - **bool**: Whether or not to create the role + policy + attachments. Used when declaring a role via a Terraform template which is NOT used across all accounts. Defaults to _true_.
+- `role_name` - **string**: Name of the IAM role to be created.
+- `role_duration` - **number**: Value of the `max_session_duration` for the role, in seconds. Defaults to _43200_ (12 hours).
+- `master_assumerole_policy` - **object**: JSON object of the policy document to attach to the role allowing AssumeRole access from a master account. Pass in using `data.aws_iam_policy_document.<DATA_SOURCE_NAME>.json` as shown in the example above.
+- `custom_policy_arns` - **list**: ARNs of any additional IAM policies to attach to the role.
+- `iam_policies` - **list(object)**: List of objects, each of which contains:
+   - `policy_name` - **string**: Name of the IAM policy to be created.
+   - `policy_description` - **string**: Description of the IAM policy.
+   - `policy_document` - **list(object)**: List of Statements included in the policy document. Each _object_ in the list should include the contents of a Statement, i.e. the `sid`, `effect`, `actions`, and `resources`.

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -45,7 +45,7 @@ resource "aws_iam_group_membership" "iam_group_members" {
 
 resource "aws_iam_group_policy_attachment" "iam_group_policies" {
   for_each = {
-    for role_name in local.account_roles: lower(role_name) => role_name
+    for role_name in local.account_roles: role_name => role_name
   }
   
   group = var.group_name

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -16,6 +16,11 @@ variable "group_name" {
   description = "Name of the IAM group."
 }
 
+variable "module_depends_on" {
+  type    = any
+  default = null
+}
+
 # -- Resources --
 
 resource "aws_iam_group" "iam_group" {
@@ -29,8 +34,9 @@ resource "aws_iam_group_membership" "iam_group_members" {
 }
 
 resource "aws_iam_group_policy_attachment" "iam_group_policies" {
-  for_each = var.assume_role_policy_arns
-
+  depends_on = [var.module_depends_on]
+  for_each = toset(var.assume_role_policy_arns)
+  
   group = var.group_name
   policy_arn = each.key
 }

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -22,8 +22,8 @@ resource "aws_iam_group" "iam_group" {
   name = var.group_name
 }
 
-resource "aws_iam_group_membership" "keymasters_members" {
-  name = "keymasters_members"
+resource "aws_iam_group_membership" "iam_group_members" {
+  name = "${var.group_name}_members"
   users = var.group_members
   group = var.group_name
 }

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -1,0 +1,36 @@
+# -- Variables --
+
+variable "assume_role_policy_arns" {
+  description = "The ARNs of IAM policies to attach to the group."
+  type        = list(any)
+  default     = []
+}
+
+variable "group_members" {
+  description = "AWS usernames of members within the group."
+  type        = list(any)
+  default     = []
+}
+
+variable "group_name" {
+  description = "Name of the IAM group."
+}
+
+# -- Resources --
+
+resource "aws_iam_group" "iam_group" {
+  name = var.group_name
+}
+
+resource "aws_iam_group_membership" "keymasters_members" {
+  name = "keymasters_members"
+  users = var.group_members
+  group = var.group_name
+}
+
+resource "aws_iam_group_policy_attachment" "iam_group_policies" {
+  for_each = var.assume_role_policy_arns
+
+  group = var.group_name
+  policy_arn = each.key
+}

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -44,8 +44,10 @@ resource "aws_iam_group_membership" "iam_group_members" {
 }
 
 resource "aws_iam_group_policy_attachment" "iam_group_policies" {
-  count = length(local.account_roles)
+  for_each = {
+    for role_name in local.account_roles: lower(role_name) => role_name
+  }
   
   group = var.group_name
-  policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${local.account_roles[count.index]}"
+  policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${each.value}"
 }

--- a/iam_masterassume/README.md
+++ b/iam_masterassume/README.md
@@ -1,0 +1,67 @@
+# `iam_assumerole`
+
+This Terraform module is designed to create all of the IAM resources necessary for cross-account AssumeRole access, via:
+
+- a role that can be assumed by any IAM user in a 'master' account with access to assume that role (via user/group privileges)
+- one or more policy documents dictating access via `statement{}` blocks
+- one or more policies created from the policy document(s)
+- one or more attachments of the role to the policy(ies)
+- (optionally) additional attachment(s) if there are other IAM policies that should be attached to the assumable role
+
+Because Policy Documents have a size limit, it is often necessary to break policies up with multiple documents. Creating multiple policies and documents is possible using a `list(object)` variable in Terraform, which allows each object in the list to contain:
+
+1. the policy name
+2. the policy description
+3. the policy document statement(s)
+
+## Example
+
+```hcl
+locals {
+  custom_policy_arns = [
+    aws_iam_policy.rds_delete_prevent.arn,
+    aws_iam_policy.region_restriction.arn,
+  ]
+  master_assumerole_policy = data.aws_iam_policy_document.master_account_assumerole.json
+}
+
+module "billing-assumerole" {
+  source = "github.com/18F/identity-terraform//iam_assumerole?ref=master"
+
+  role_name                = "BillingReadOnly"
+  enabled                  = var.iam_billing_enabled
+  master_assumerole_policy = local.master_assumerole_policy
+  custom_policy_arns       = local.custom_policy_arns
+
+  iam_policies = [
+    {
+      policy_name        = "BillingReadOnly"
+      policy_description = "Policy for reporting group read-only access to Billing ui"
+      policy_document    = [
+        {
+          sid    = "BillingReadOnly"
+          effect = "Allow"
+          actions = [
+            "aws-portal:ViewBilling",
+          ]
+          resources = [
+            "*",
+          ]
+        },
+      ]
+    },
+  ]
+}
+```
+
+## Variables
+
+- `enabled` - **bool**: Whether or not to create the role + policy + attachments. Used when declaring a role via a Terraform template which is NOT used across all accounts. Defaults to _true_.
+- `role_name` - **string**: Name of the IAM role to be created.
+- `role_duration` - **number**: Value of the `max_session_duration` for the role, in seconds. Defaults to _43200_ (12 hours).
+- `master_assumerole_policy` - **object**: JSON object of the policy document to attach to the role allowing AssumeRole access from a master account. Pass in using `data.aws_iam_policy_document.<DATA_SOURCE_NAME>.json` as shown in the example above.
+- `custom_policy_arns` - **list**: ARNs of any additional IAM policies to attach to the role.
+- `iam_policies` - **list(object)**: List of objects, each of which contains:
+   - `policy_name` - **string**: Name of the IAM policy to be created.
+   - `policy_description` - **string**: Description of the IAM policy.
+   - `policy_document` - **list(object)**: List of Statements included in the policy document. Each _object_ in the list should include the contents of a Statement, i.e. the `sid`, `effect`, `actions`, and `resources`.

--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -1,0 +1,34 @@
+# -- Variables --
+
+variable "account_numbers" {
+  description = "List of AWS account numbers where this policy can access the specified Assumable role"
+  type = list(any)
+}
+
+variable "role_type" {
+  description = "Type/name of the Assumable role. Should correspond to an actual role name in the account(s) listed."
+}
+
+variable "account_type" {
+  description = "Type/name that the listed account(s) fall under (e.g. prod, dev, etc.)"
+}
+
+# -- Resources --
+
+resource "aws_iam_policy" "role_type_policy" {
+  name        = join("", [title(var.account_type), "Assume", title(var.role_type)]))
+  path        = "/"
+  description = "Policy to allow user to assume ${var.role_type} role in ${var.account_type}."
+  policy      = data.aws_iam_policy_document.role_type_policy.json
+}
+
+data "aws_iam_policy_document" "role_type_policy" {
+  statement {
+    sid    = join("", [title(var.account_type), "Assume", title(var.role_type)]))
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = formatlist("arn:aws:iam::%s:role/${var.role_type}",var.account_numbers)
+  }
+}

--- a/iam_masterusers/README.md
+++ b/iam_masterusers/README.md
@@ -1,0 +1,23 @@
+# `iam_masteruser`
+
+This Terraform module can be used to create one or more IAM users.
+Group memberships are assigned per-user for simpler user management.
+
+## Example
+
+```hcl
+module "our_cool_master_users" {
+  source = "github.com/18F/identity-terraform//iam_masterusers?ref=master"
+  
+  user_map = {
+    'fred.flinstone' = ['development'],
+    'barny.rubble' = ['devops'],
+    'space.ghost' = ['devops', 'host'],
+  }
+}
+```
+
+## Variables
+
+`user_map` - Map with user name as key and a list of group memberships
+             as the value.

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -1,0 +1,21 @@
+variable "user_map" {
+  description = "Map of users to group memberships."
+  type        = map(list(string))
+}
+
+
+# -- Resources --
+
+resource "aws_iam_user" "master_user" {
+  for_each = var.user_map
+
+  name          = each.key
+  force_destroy = true
+}
+
+resource "aws_iam_user_group_membership" "master_user" {
+  for_each = var.user_map
+
+  user = each.key
+  groups = each.value
+}


### PR DESCRIPTION
A riff on #40 with the account type to account list mapping passed in as one map AND users as a map of user to group by way of a new `iam_masterusers` module.