### PR TITLE
adding depends_on functionality between iam_assumegroup and iam_masterassume

### DIFF
--- a/iam_assumegroup/README.md
+++ b/iam_assumegroup/README.md
@@ -3,10 +3,6 @@
 This Terraform module can be used to create one or more IAM groups, along with attached group policies.
 The design is calculated from a map of the groups, and per-"Account Type" access levels, supplied as input.
 
-If Terraform is dependent upon the ARNs to be calculated outside of this module,
-it will be stuck in a circular dependency loop.
-Thus, the policy ARNs are created from the input map.
-
 ## Account Type
 
 The "account type" concept allows for more granular control of permissions for IAM groups
@@ -70,3 +66,7 @@ module "devops_group" {
   ]
 }
 ```
+`policy_depends_on` - If Terraform is dependent upon the policy ARNs to be _calculated_ outside of this module,
+it will be stuck in a circular dependency loop. Thus, the policy ARNs are created from the input map.
+However, `policy_depends_on` can be used to wait for those policies to ACTUALLY exist
+before attempting to create the policy attachments.

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -9,6 +9,16 @@ variable "group_role_map" {
   type = map(list(map(list(string))))
 }
 
+variable "policy_depends_on" {
+  description = <<EOM
+(Optional) Will force each given aws_iam_policy_attachment to verify that
+the specified value (i.e. another resource, such as the respective
+group_policy) exists before it is created.
+EOM
+  type    = any
+  default = null
+}
+
 locals {
   role_group_map = transpose(
     {
@@ -35,5 +45,7 @@ resource "aws_iam_policy_attachment" "group_policy" {
   name       = each.key
   groups     = each.value
   policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${each.key}"
+
+  depends_on = [var.policy_depends_on]
 }
 

--- a/iam_masterassume/README.md
+++ b/iam_masterassume/README.md
@@ -51,3 +51,8 @@ module "assume_roles_prod" {
 - `account_type`: The "type", aka "category", of AWS account(s) that this module will create policies for.
 - `account_numbers`: A list of AWS account number(s) within the `account_type` category.
 - `role_list`: A list of the roles available to be assumed from within the account(s).
+
+## Outputs
+
+- `policy_arns`: A list of the ARNs of the newly-created policies. Reference this output in order to depend on policy creation being complete.
+

--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -46,3 +46,10 @@ resource "aws_iam_policy" "account_role_policy" {
   description = "Policy to allow user to assume ${split("Assume", each.key)[1]} role in ${split("Assume", each.key)[0]} account(s)."
   policy = data.aws_iam_policy_document.role_policy_doc[each.key].json
 }
+
+# -- Outputs --
+
+output "policy_arns" {
+  description = "Reference this output in order to depend on policy creation being complete."
+  value       = values(aws_iam_policy.account_role_policy)[*]["arn"]
+}


### PR DESCRIPTION
## TL;DR

The `policy_depends_on` variable in `iam_assumegroup` can be used in conjunction with another value, i.e. the output `policy_arns` in the `iam_masterassume` module, to make `iam_assumegroup` wait for specific IAM policies to exist before attempting to create their respective group attachments.

## Detail

The `iam_assumegroup` module is used to attach IAM policies to groups, and the policies themselves are generated OUTSIDE of this module (and done instead within `iam_masterassume`). Terraform is unable to calculate the proper policy ARNs itself due to this circular dependency, so the `role_group_map` is used with the `master_account_id` to generate the ARN values in the same module.

HOWEVER: If the policies do not already exist before Terraform attempts to create these attachments, the `apply` operation will fail -- even if other resources/modules within it create the policies in parallel. This means that a _subsequent_ `apply` will be successful, but creates too much possibility of orphaned resources / inconsistent state.

This PR solves this dependency loop:

1. Since Terraform does not currently support `depends_on` capabilities on a `module` basis, the variable `policy_depends_on` can be used instead on a per-resource basis, causing the policy attachment creation to wait until _all_ other resources specified by the value(s) in `policy_depends_on` exist (i.e. IAM policy ARNs).
2. To provide a value for `policy_depends_on` the `iam_masterassume` module now provides an output, `policy_arns`, which is a list of the ARNs of all policies created by `iam_masterassume`. This list is not populated until _all_ policies have been created.