### PR TITLE
fixing dependencies between modules + adding ListAttachedGroupPolicies permission

### DIFF
--- a/iam_assumegroup/README.md
+++ b/iam_assumegroup/README.md
@@ -70,3 +70,8 @@ module "devops_group" {
 it will be stuck in a circular dependency loop. Thus, the policy ARNs are created from the input map.
 However, `policy_depends_on` can be used to wait for those policies to ACTUALLY exist
 before attempting to create the policy attachments.
+
+## Outputs
+
+- `group_names`: A list of the names of the newly-created groups. Reference this output in order to depend on group creation being complete.
+

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -49,3 +49,9 @@ resource "aws_iam_policy_attachment" "group_policy" {
   depends_on = [var.policy_depends_on]
 }
 
+# -- Outputs --
+
+output "group_names" {
+  description = "Reference this output in order to depend on group creation being complete."
+  value       = values(aws_iam_group.iam_group)[*]["name"]
+}

--- a/iam_masterusers/README.md
+++ b/iam_masterusers/README.md
@@ -32,4 +32,5 @@ module "our_cool_master_users" {
 `user_map` - Map with user name as key and a list of group memberships as the value.
 `allow_self_management` - Whether or not to create the 'ManageYourAccount' IAM policy
 and attach it to all users in var.user_map in this account.
-
+`group_depends_on` - Can be used to wait for the groups in `user_map` to ACTUALLY exist
+before attempting to create the group memberships.

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -14,6 +14,16 @@ EOM
   default     = true
 }
 
+variable "group_depends_on" {
+  description = <<EOM
+(Optional) Will force each given aws_iam_group_membership to verify that
+the specified value (i.e. another resource, such as the respective
+group) exists before it is created.
+EOM
+  type    = any
+  default = null
+}
+
 # -- Resources --
 
 resource "aws_iam_user" "master_user" {
@@ -29,6 +39,10 @@ resource "aws_iam_group_membership" "master_group" {
   name = "${each.key}-group"
   group = each.key
   users = each.value
+  depends_on = [
+    aws_iam_user.master_user,
+    var.group_depends_on
+  ]
 }
 
 resource "aws_iam_policy" "manage_your_account" {
@@ -55,6 +69,7 @@ data "aws_iam_policy_document" "manage_your_account" {
     actions = [
       "iam:ListAccountAliases",
       "iam:ListUsers",
+      "iam:ListAttachedGroupPolicies",
       "iam:ListVirtualMFADevices",
       "iam:GetAccountPasswordPolicy",
       "iam:GetAccountSummary",


### PR DESCRIPTION
With the previous code, creating new users AND groups simultaneously caused Terraform to fail, as it could not create the `aws_iam_group_membership` resources until both the users AND the groups existed. This adds a "fake" `depends_on` variable to accommodate that scenario.

Also: Adds the `iam:ListAttachedGroupPolicies` permission so that a user can see which policies they can access, based on the group(s) they are in.