### PR TITLE
using aws_iam_user_policy_attachment for manage_your_account resource

### DIFF
--- a/iam_masterusers/README.md
+++ b/iam_masterusers/README.md
@@ -3,15 +3,12 @@
 This Terraform module can be used to create one or more IAM users.
 Group memberships are assigned per-user for simpler user management.
 
-By default, an IAM policy called ***ManageYourAccount*** will also be created,
+An IAM policy called ***ManageYourAccount*** will also be created,
 which is attached to all users in `user_map`. It allows each user
 basic access to configure their own account, i.e. updating their own
 password, adding an MFA device, etc., and sets an explicit **Deny** on
 numerous actions -- *including* `sts:AssumeRole` -- if the user does
 not have an MFA device configured.
-
-The creation of this IAM policy can be disabled by setting the variable
-`allow_self_management` to **false**.
 
 ## Example
 
@@ -30,7 +27,5 @@ module "our_cool_master_users" {
 ## Variables
 
 `user_map` - Map with user name as key and a list of group memberships as the value.
-`allow_self_management` - Whether or not to create the 'ManageYourAccount' IAM policy
-and attach it to all users in var.user_map in this account.
 `group_depends_on` - Can be used to wait for the groups in `user_map` to ACTUALLY exist
 before attempting to create the group memberships.


### PR DESCRIPTION
If using an `aws_iam_policy_attachment` resource to attach the `manage_your_account` policy to a user, Terraform does not understand the relationship between the resources. This means that Terraform will fail when it:

1. attempts to create the policy attachment before the user exists (i.e. creating resources simultaneously)
2. delete the user before the policy attachment is removed (if the attachment's creation is dependent upon the user resource)

This changes the resource to use an `aws_iam_user_policy_attachment` resource instead, allowing it to properly manage both resources in whichever order they are altered.