### PR TITLE
use actual aws_iam_user.master_user resource instead of var.user_map to create aws_iam_user_policy_attachment

### DIFF
--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -44,7 +44,7 @@ resource "aws_iam_policy" "manage_your_account" {
 }
 
 resource "aws_iam_user_policy_attachment" "manage_your_account" {
-  for_each = var.user_map
+  for_each = aws_iam_user.master_user
   
   user       = each.key
   policy_arn = aws_iam_policy.manage_your_account.arn


### PR DESCRIPTION
Ignore what I said in the last PR because that clearly was false ಠ_ಠ

Makes the `aws_iam_user_policy_attachment` resource utilize the ACTUAL `aws_iam_user.master_user` resource set. Eliminates need for `depends_on` and/or creation/deletion dependencies.