### PR TITLE
moving primary_verification_record out of module for multi-region support

### DIFF
--- a/ses_dkim_r53/README.md
+++ b/ses_dkim_r53/README.md
@@ -5,6 +5,8 @@ Given a domain name and a Route53 zone ID, this Terraform module will create:
 - an SES identity resource for the provided domain + corresponding Route53 TXT verification record
 - three (3) SES domain DKIM generation resources for the provided domain + corresponding Route53 CNAME records
 
+***NOTE:*** To allow for multi-region support, a `aws_route53_record.primary_verification_record` resource must be created separately (i.e. in the parent module), which uses the output value `ses_token` from each instance of `aws_ses_domain_identity.primary`.
+
 ## Example
 
 ```hcl
@@ -13,7 +15,6 @@ module "core_ses" {
 
   domain                    = var.root_domain
   zone_id                   = module.common_dns.primary_zone_id
-  ttl_verification_record   = "1800"
   ttl_dkim_records          = "1800"
 }
 ```
@@ -22,5 +23,4 @@ module "core_ses" {
 
 - `domain` - Name of the owned/managed domain.
 - `zone_id` - ID for the Route53 zone where the domain exists.
-- `ttl_verification_record` - TTL value for the SES verification TXT record. Defaults to ***1800***.
 - `ttl_dkim_records` - TTL value for the SES DKIM records. Defaults to ***1800***.

--- a/ses_dkim_r53/main.tf
+++ b/ses_dkim_r53/main.tf
@@ -12,25 +12,10 @@ variable "zone_id" {
   default     = "ABCDEFGHIJ123"
 }
 
-variable "ttl_verification_record" {
-  description = "TTL value for the SES verification TXT record."
-  type        = string
-  default     = "1800"
-}
-
 variable "ttl_dkim_records" {
   description = "TTL value for the SES DKIM records."
   type        = string
   default     = "1800"
-}
-
-variable "create_token" {
-  description = <<EOM
-Whether or not to create a primary_verification_record in Route53.
-Set to FALSE if this TXT record has been created with multiple entries.
-EOM
-  type        = bool
-  default     = true
 }
 
 # -- Resources --
@@ -43,15 +28,6 @@ resource "aws_ses_domain_dkim" "primary" {
   domain = aws_ses_domain_identity.primary.domain
 }
 
-resource "aws_route53_record" "primary_verification_record" {
-  count   = var.create_token ? 1 : 0
-  zone_id = var.zone_id
-  name    = "_amazonses.${var.domain}"
-  type    = "TXT"
-  ttl     = var.ttl_verification_record
-  records = ["${aws_ses_domain_identity.primary.verification_token}"]
-}
-
 resource "aws_route53_record" "primary_ses_dkim" {
   count   = 3
   zone_id = var.zone_id
@@ -59,4 +35,9 @@ resource "aws_route53_record" "primary_ses_dkim" {
   type    = "CNAME"
   ttl     = var.ttl_dkim_records
   records = ["${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
+
+output "ses_token" {
+  description = "Token for the primary verification record in Route 53."
+  value = aws_ses_domain_identity.primary.verification_token
 }


### PR DESCRIPTION
As per my addition to the README:

> To allow for multi-region support, a `aws_route53_record.primary_verification_record` resource must be created separately (i.e. in the parent module), which uses the output value `ses_token` from each instance of `aws_ses_domain_identity.primary`.