### PR TITLE
s3_bucket_block: iterative S3 bucket + block generation

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -1,10 +1,6 @@
 data "aws_caller_identity" "current" {
 }
 
-data "aws_s3_bucket" "ct_log_bucket" {
-  bucket = "login-gov-cloudtrail-${data.aws_caller_identity.current.account_id}"
-}
-
 data "aws_iam_policy_document" "kms" {
   # Allow root users in
   statement {

--- a/s3_bucket_block/README.md
+++ b/s3_bucket_block/README.md
@@ -1,0 +1,68 @@
+# `s3_bucket_block`
+
+This Terraform module is designed to create an S3 bucket, or a set of buckets, from a map variable containing various bucket configurations. It provides consistency for the following, in all buckets provided:
+
+- Bucket naming scheme
+- Versioning enabled
+- Logging enabled (an S3 'log' bucket is also created)
+- KMS SSE
+
+## Dynamic Settings
+
+By default, only the bucket's name is needed within the provided `bucket_data` map variable. This is built from:
+- `var.bucket_prefix`
+- `each.key` (in the `bucket_data` map variable)
+- `data.aws_caller_identity.current.account_id`
+- `var.region`
+
+The following additional settings can be configured via key-value pairs in the map:
+- `acl` (defaults to `private`)
+- `policy` (defaults to `""`)
+- `force_destroy` (defaults to `true`)
+- `lifecycle_rules` (list, defaults to `[]` and does not create any lifecycle rules unless provided)
+- `public_access_block` (defaults to `false`; if set to true, the module will also create an `aws_s3_bucket_public_access_block` resource for the accordant bucket)
+
+## Example
+
+```hcl
+module "s3_shared" {
+    source = "github.com/18F/identity-terraform//s3_bucket_block?ref=master"
+    
+    bucket_prefix = "login-gov"
+    bucket_data = {
+        "shared-data" = {
+            policy = data.aws_iam_policy_document.shared.json
+        },
+        "lambda-functions" = {
+            policy          = data.aws_iam_policy_document.lambda-functions.json
+            lifecycle_rules = [
+                {
+                    id          = "inactive"
+                    enabled     = true
+                    prefix      = "/"
+                    transitions = [
+                        {
+                            days          = 180
+                            storage_class = "STANDARD_IA"
+                        }
+                    ]
+                }
+            ],
+            force_destroy = false
+        }, 
+        "waf-logs" = {},
+    }
+}
+```
+
+## Variables
+
+`bucket_prefix` - First substring in S3 bucket name of `$bucket_prefix.$bucket_name.$account_id-$region`
+`bucket_data` - Map of bucket names and their configuration blocks.
+`log_bucket` - Substring for the name of the bucket used for S3 logging.
+`region` - AWS Region
+
+## Outputs
+
+`buckets` - A map of the format `var.bucket_data.each.key` => `aws_s3_bucket.bucket[*]["id"]` allowing one to obtain the full bucket name from the shorter key reference.
+

--- a/s3_bucket_block/README.md
+++ b/s3_bucket_block/README.md
@@ -20,7 +20,7 @@ The following additional settings can be configured via key-value pairs in the m
 - `policy` (defaults to `""`)
 - `force_destroy` (defaults to `true`)
 - `lifecycle_rules` (list, defaults to `[]` and does not create any lifecycle rules unless provided)
-- `public_access_block` (defaults to `false`; if set to true, the module will also create an `aws_s3_bucket_public_access_block` resource for the accordant bucket)
+- `public_access_block` (defaults to `true`; creates an `aws_s3_bucket_public_access_block` resource for the accordant bucket)
 
 ## Example
 

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -120,7 +120,7 @@ resource "aws_s3_bucket_public_access_block" "block" {
   for_each = toset(
     compact(
       [ for bucket, data in var.bucket_data :
-        lookup(data, "public_access_block", false) ? bucket : ""
+        lookup(data, "public_access_block", true) ? bucket : ""
       ]
     )
   )

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -5,7 +5,7 @@ variable "bucket_prefix" {
 }
 
 variable "bucket_data" {
-  description = "Map of bucket names and their lifecycle rule blocks."
+  description = "Map of bucket names and their configuration blocks."
   type        = any
   default     = {}
 }
@@ -114,9 +114,6 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "block" {
@@ -142,6 +139,8 @@ output "log_bucket" {
 }
 
 output "buckets" {
-  description = "IDs of the buckets created from bucket_data."
-  value       = values(aws_s3_bucket.bucket)[*]["id"]
+  description = "Map of the bucket names:ids created from bucket_data."
+  value       = zipmap(
+      sort(keys(var.bucket_data)),
+      sort(values(aws_s3_bucket.bucket)[*]["id"]))
 }

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -1,0 +1,131 @@
+# -- Variables --
+variable "bucket_prefix" {
+  description = "First substring in S3 bucket name of $bucket_prefix.$bucket_name.$account_id-$region"
+  type        = string
+  default     = "login-gov"
+}
+
+variable "bucket_data" {
+  description = "Map of bucket names and their lifecycle rule blocks."
+  type        = list(any)
+  default     = [
+    {
+    name = "s3-email",
+    acl    = "private",
+    policy = "",
+    lifecycle_rules = [
+      {
+        id      = "expireinbound"
+        enabled = true
+        prefix = "/inbound/"
+    
+        transition = {
+          days          = 30
+          storage_class = "STANDARD_IA"
+        }
+    
+        expiration = {
+          days = 365
+        }
+      }
+    ],
+    public_access_block = true
+  },
+]
+}
+
+variable "log_bucket" {
+  description = "Substring for the name of the bucket used for S3 logging."
+  type        = string
+  default     = "s3-logs"
+}
+
+# -- Data Sources --
+data "aws_caller_identity" "current" {
+}
+
+# -- Resources --
+resource "aws_s3_bucket" "s3-logs" {
+  bucket = "${var.bucket_prefix}.${var.log_bucket}.${data.aws_caller_identity.current.account_id}-${var.region}"
+  region = var.region
+  acl    = "log-delivery-write"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "expirelogs"
+    enabled = true
+
+    prefix = "/"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 365
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      # 5 years
+      days = 1825
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket" "bucket" {
+  for_each = var.bucket_list
+
+  bucket = "${var.bucket_prefix}.${each.value.name}.${data.aws_caller_identity.current.account_id}-${var.region}"
+  region = var.region
+  acl    = each.value.acl
+  policy = each.value.policy
+
+  logging {
+    target_bucket = aws_s3_bucket.s3-logs.id
+    target_prefix = "${var.bucket_prefix}.${each.value.name}.${data.aws_caller_identity.current.account_id}-${var.region}/"
+  }
+
+  dynamic "lifecycle_rule" {
+    for_each = each.value.lifecycle_rules
+    content {
+      id      = lifecycle_rule.value["id"]
+      enabled = lifecycle_rule.value["enabled"]
+      prefix = lifecycle_rule.value["prefix"]
+      transition = lifecycle_rule.value["transition"]
+      expiration = lifecycle_rule.value["expiration"]
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "block" {
+  for_each = compact([ for bucket in var.bucket_data : bucket.public_access_block ? bucket.name : ""])
+  
+  bucket                  = aws_s3_bucket.bucket[each.key].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# -- Outputs --

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -136,6 +136,12 @@ resource "aws_s3_bucket_public_access_block" "block" {
 }
 
 # -- Outputs --
-output "s3_log_bucket" {
-  value = aws_s3_bucket.s3-logs.id
+output "log_bucket" {
+  description = "ID of the log bucket."
+  value       = aws_s3_bucket.s3-logs.id
+}
+
+output "buckets" {
+  description = "IDs of the buckets created from bucket_data."
+  value       = values(aws_s3_bucket.bucket)[*]["id"]
 }


### PR DESCRIPTION
As per the README.md:

# `s3_bucket_block`

This Terraform module is designed to create an S3 bucket, or a set of buckets, from a map variable containing various bucket configurations. It provides consistency for the following, in all buckets provided:

- Bucket naming scheme
- Versioning enabled
- Logging enabled (an S3 'log' bucket is also created)
- KMS SSE

## Dynamic Settings

By default, only the bucket's name is needed within the provided `bucket_data` map variable. This is built from:
- `var.bucket_prefix`
- `each.key` (in the `bucket_data` map variable)
- `data.aws_caller_identity.current.account_id`
- `var.region`

The following additional settings can be configured via key-value pairs in the map:
- `acl` (defaults to `private`)
- `policy` (defaults to `""`)
- `force_destroy` (defaults to `true`)
- `lifecycle_rules` (list, defaults to `[]` and does not create any lifecycle rules unless provided)
- `public_access_block` (defaults to `false`; if set to true, the module will also create an `aws_s3_bucket_public_access_block` resource for the accordant bucket)

## Example

```hcl
module "s3_shared" {
    source = "github.com/18F/identity-terraform//s3_bucket_block?ref=master"
    
    bucket_prefix = "login-gov"
    bucket_data = {
        "shared-data" = {
            policy = data.aws_iam_policy_document.shared.json
        },
        "lambda-functions" = {
            policy          = data.aws_iam_policy_document.lambda-functions.json
            lifecycle_rules = [
                {
                    id          = "inactive"
                    enabled     = true
                    prefix      = "/"
                    transitions = [
                        {
                            days          = 180
                            storage_class = "STANDARD_IA"
                        }
                    ]
                }
            ],
            force_destroy = false
        }, 
        "waf-logs" = {},
    }
}
```

## Variables

`bucket_prefix` - First substring in S3 bucket name of `$bucket_prefix.$bucket_name.$account_id-$region`
`bucket_data` - Map of bucket names and their configuration blocks.
`log_bucket` - Substring for the name of the bucket used for S3 logging.
`region` - AWS Region

## Outputs

`buckets` - A map of the format `var.bucket_data.each.key` => `aws_s3_bucket.bucket[*]["id"]` allowing one to obtain the full bucket name from the shorter key reference.