### PR TITLE
adding multiregion support to kms_log module

### DIFF
--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -2,7 +2,7 @@ variable "env_name" {
   description = "Environment name"
 }
 
-variable "region" {
+variable "module_region" {
   default     = "us-west-2"
   description = "AWS Region"
 }


### PR DESCRIPTION
Does what it says on the tin.

Not the most thorough/clean/extensive refactoring job, but it allows both a different `provider` and region to be specified for the module, allowing for creation of KMS keys (and all other resources) in additional regions.