### PR TITLE
make aws_s3_bucket_public_access_block wait for bucket to exist

### DIFF
--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -124,6 +124,7 @@ resource "aws_s3_bucket_public_access_block" "block" {
       ]
     )
   )
+  depends_on = [aws_s3_bucket.bucket]
   
   bucket                  = aws_s3_bucket.bucket[each.key].id
   block_public_acls       = true


### PR DESCRIPTION
Since the `s3_bucket_block` module builds its resources from `for_each` loops, it attempts to create the `aws_s3_bucket_public_access_block` resources at the same time that it's creating their respective buckets. This adds a `depends_on` argument, making the module wait until the buckets exist before attempting to create their access blocks.