### PR TITLE
splitting out kms_log + kms_keymaker

### DIFF
--- a/kms_keymaker/README.md
+++ b/kms_keymaker/README.md
@@ -1,0 +1,25 @@
+# `kms_keymaker`
+
+This Terraform module will generate a KMS key + alias for use by the Login.gov IdP application, along with a CloudWatch event monitor, and its target (an SNS topic/subscription). It is best utilized alongside the `kms_log` module, which creates the SQS queue (whose ARN is a required variable in this module) that SNS sends messages to.
+
+These resources were, previously, all included within `kms_log` in a more monolithic design; they have been split out separately to allow for multi-region KMS keys and associated resources.
+
+## Example
+
+```hcl
+module "kms_keymaker_uw2" {
+  source = "github.com/18F/identity-terraform//kms_keymaker?ref=master"
+
+  env_name                   = "testing"
+  ec2_kms_arns               = local.kms_arns
+  kmslogging_service_enabled = 1
+  sqs_queue_arn = module.kms_logging.kms-ct-events-queue
+}
+```
+
+## Variables
+
+`ec2_kms_arns` - ARN(s) of EC2 roles permitted access to KMS
+`env_name` - Environment name
+`sqs_queue_arn` - ARN of the SQS queue used as the CloudWatch event target.
+`kmslogging_service_enabled` - Enable KMS Logging service. If disabled the CloudWatch rule will not be created.

--- a/kms_keymaker/main.tf
+++ b/kms_keymaker/main.tf
@@ -1,0 +1,97 @@
+# -- Variables --
+
+variable "ec2_kms_arns" {
+  default     = []
+  description = "ARN(s) of EC2 roles permitted access to KMS"
+}
+
+variable "env_name" {
+  description = "Environment name"
+}
+
+variable "region" {
+  default     = "us-west-2"
+  description = "AWS Region"
+}
+
+# -- Data Sources --
+
+data "aws_caller_identity" "current" {
+}
+
+data "aws_iam_policy_document" "kms" {
+  # Allow root users in
+  statement {
+    actions = [
+      "kms:*",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+    resources = [
+      "*",
+    ]
+  }
+
+  # allow an EC2 instance role to use KMS
+  statement {
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = concat(
+        var.ec2_kms_arns
+      )
+    }
+    resources = [
+      "*",
+    ]
+  }
+
+  # Allow CloudWatch Events and SNS Access
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = [
+      "*",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "sns.amazonaws.com",
+      ]
+    }
+  }
+}
+
+# -- Resources --
+
+resource "aws_kms_key" "login-dot-gov-keymaker" {
+  enable_key_rotation = true
+  description         = "${var.env_name}-login-dot-gov-keymaker"
+  policy              = data.aws_iam_policy_document.kms.json
+}
+
+resource "aws_kms_alias" "login-dot-gov-keymaker-alias" {
+  name          = "alias/${var.env_name}-login-dot-gov-keymaker"
+  target_key_id = aws_kms_key.login-dot-gov-keymaker.key_id
+}
+
+# -- Outputs --
+
+output "keymaker_arn" {
+  description = "ARN of the login-dot-gov-keymaker KMS key."
+  value = aws_kms_key.login-dot-gov-keymaker.arn
+}

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -1,8 +1,3 @@
-variable "keymaker_key_ids" {
-  description = "List of login-dot-gov-keymaker Key ID(s)."
-  default = []
-}
-
 variable "env_name" {
   description = "Environment name"
 }

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -1,3 +1,8 @@
+variable "keymaker_key_ids" {
+  description = "List of login-dot-gov-keymaker Key ID(s)."
+  default = []
+}
+
 variable "env_name" {
   description = "Environment name"
 }


### PR DESCRIPTION
To allow for multi-region support + creation of KMS keys, this PR splits out the necessary resources for the `login-dot-gov-keymaker` KMS key + monitoring into a new module, `kms_keymaker`. This includes:

- KMS key + alias
- CloudWatch event rule on `Decrypt` events with `password-digest` / `pii-encryption` context
- SNS topic + subscription which sends to an SQS queue (created in `kms_log`)
- In-between resources (SNS topic policy, CloudWatch event target, etc.)

`kms_log` has also been updated, primarily to allow the above resources to be abstracted out, and also to grant permissions for SNS (instead of CloudWatch) to send messages to the SQS queue. The new design allows for multi-region message delivery, since a single SQS queue can receive subscription notifications across regions.