### PR TITLE
Remove kmslogging_service_enabled flag

### DIFF
--- a/kms_keymaker/README.md
+++ b/kms_keymaker/README.md
@@ -12,7 +12,6 @@ module "kms_keymaker_uw2" {
 
   env_name                   = "testing"
   ec2_kms_arns               = local.kms_arns
-  kmslogging_service_enabled = 1
   sqs_queue_arn = module.kms_logging.kms-ct-events-queue
 }
 ```
@@ -22,4 +21,3 @@ module "kms_keymaker_uw2" {
 `ec2_kms_arns` - ARN(s) of EC2 roles permitted access to KMS
 `env_name` - Environment name
 `sqs_queue_arn` - ARN of the SQS queue used as the CloudWatch event target.
-`kmslogging_service_enabled` - Enable KMS Logging service. If disabled the CloudWatch rule will not be created.

--- a/kms_keymaker/main.tf
+++ b/kms_keymaker/main.tf
@@ -13,11 +13,6 @@ variable "sqs_queue_arn" {
   description = "ARN of the SQS queue used as the CloudWatch event target."
 }
 
-variable "kmslogging_service_enabled" {
-  default     = 0
-  description = "Enable KMS Logging service.  If disabled the CloudWatch rule will not be created."
-}
-
 # -- Data Sources --
 
 data "aws_caller_identity" "current" {
@@ -80,34 +75,6 @@ data "aws_iam_policy_document" "kms" {
   }
 }
 
-data "aws_iam_policy_document" "kms_events_topic_policy" {
-  policy_id = "kms_ct_sqs"
-
-  statement {
-    sid = "KMSCTSQS"
-    actions = [
-      "SNS:Publish",
-    ]
-
-#    condition {
-#      test     = "StringLike"
-#      variable = "aws:SourceArn"
-#      values = [aws_cloudwatch_event_rule.decrypt[0].arn]
-#    }
-
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-
-    resources = [
-      aws_sns_topic.kms_events[0].arn
-    ]
-  }
-}
-
 # -- Resources --
 
 resource "aws_kms_key" "login-dot-gov-keymaker" {
@@ -130,8 +97,6 @@ data "aws_kms_key" "application" {
 # encryption context is set and has the values of
 # password-digest or pii-encryption
 resource "aws_cloudwatch_event_rule" "decrypt" {
-  count = var.kmslogging_service_enabled
-
   name        = "${var.env_name}-decryption-events"
   description = "Capture decryption events"
 
@@ -171,16 +136,12 @@ PATTERN
 
 # SNS topic to send decryption events to SQS
 resource "aws_sns_topic" "kms_events" {
-  count = var.kmslogging_service_enabled
-
   name = "${var.env_name}-decryption-events"
 }
 
 # endpoint subscription for SNS->SQS (for multi-region support)
 resource "aws_sns_topic_subscription" "kms_ct_sqs" {
-  count = var.kmslogging_service_enabled
-
-  topic_arn = aws_sns_topic.kms_events[count.index].arn
+  topic_arn = aws_sns_topic.kms_events.arn
   protocol  = "sqs"
   endpoint  = var.sqs_queue_arn
 }
@@ -188,16 +149,41 @@ resource "aws_sns_topic_subscription" "kms_ct_sqs" {
 # sets the receiver of the cloudwatch events
 # to the SNS topic
 resource "aws_cloudwatch_event_target" "sns" {
-  count = var.kmslogging_service_enabled
-
-  rule      = aws_cloudwatch_event_rule.decrypt[count.index].name
+  rule      = aws_cloudwatch_event_rule.decrypt.name
   target_id = "${var.env_name}-sns"
-  arn       = aws_sns_topic.kms_events[count.index].arn
+  arn       = aws_sns_topic.kms_events.arn
+}
+
+data "aws_iam_policy_document" "kms_events_topic_policy" {
+  policy_id = "kms_ct_sqs"
+
+  statement {
+    sid = "KMSCTSQS"
+    actions = [
+      "SNS:Publish",
+    ]
+
+#    condition {
+#      test     = "StringLike"
+#      variable = "aws:SourceArn"
+#      values = [aws_cloudwatch_event_rule.decrypt.arn]
+#    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    resources = [
+      aws_sns_topic.kms_events.arn
+    ]
+  }
 }
 
 resource "aws_sns_topic_policy" "kms_events" {
-  count = var.kmslogging_service_enabled
-  arn = aws_sns_topic.kms_events[count.index].arn
+  arn = aws_sns_topic.kms_events.arn
 
   policy = data.aws_iam_policy_document.kms_events_topic_policy.json
 }

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -7,11 +7,6 @@ variable "region" {
   description = "AWS Region"
 }
 
-variable "kmslogging_service_enabled" {
-  default     = 0
-  description = "Enable KMS Logging service.  If disabled the CloudWatch rule will not be created."
-}
-
 variable "kinesis_shard_count" {
   default     = 1
   description = "Number of shards to allocate to Kinesis data stream"


### PR DESCRIPTION
Removes kmslogging_service_enabled from `kms_log` and `kms_keymaker` modules.

The following state moves are required after which a `plan` should be empty:
~~~
aws-vault exec ACCOUNT -- zsh

export ENVIR=<ENVIRONMENT_NAME>

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_cloudwatch_event_rule.unmatched[0]' \
  'module.kms_logging.aws_cloudwatch_event_rule.unmatched'

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_cloudwatch_event_target.unmatched[0]' \
  'module.kms_logging.aws_cloudwatch_event_target.unmatched'

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_lambda_function.cloudtrail_processor[0]' \
  'module.kms_logging.aws_lambda_function.cloudtrail_processor'

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_lambda_event_source_mapping.cloudtrail_processor[0]' \
  'module.kms_logging.aws_lambda_event_source_mapping.cloudtrail_processor'

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_lambda_function.cloudwatch_processor[0]' \
  'module.kms_logging.aws_lambda_function.cloudwatch_processor'

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_lambda_event_source_mapping.cloudwatch_processor[0]' \
  'module.kms_logging.aws_lambda_event_source_mapping.cloudwatch_processor'

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_lambda_function.event_processor[0]' \
  'module.kms_logging.aws_lambda_function.event_processor'

tf-deploy $ENVIR app state mv \
  'module.kms_logging.aws_lambda_event_source_mapping.event_processor[0]' \
  'module.kms_logging.aws_lambda_event_source_mapping.event_processor'
~~~