### PR TITLE
Add use_spot_instances option to launch_template

### DIFF
--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -46,6 +46,12 @@ variable "block_device_mappings" {
   default     = []
 }
 
+variable "use_spot_instances" {
+  description = "Use spot instances - Only suitable if one or more terminated instances are acceptable"
+  type        = number
+  default     = 0
+}
+
 # ----
 
 resource "aws_launch_template" "template" {
@@ -60,6 +66,19 @@ resource "aws_launch_template" "template" {
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
 
   instance_type = var.instance_type
+
+  dynamic "instance_market_options" {
+    for_each = var.use_spot_instances == 1 ? [1] : []
+
+    content {
+      market_type = "spot"
+
+      # ASG will take care of replacing terminated instances
+      spot_options {
+        spot_instance_type = "one-time"
+      }
+    }
+  }
 
   user_data = var.user_data
 


### PR DESCRIPTION
Adds `use_spot_instances` variable to `launch_template`.  Set to 0 (off) by default.  If set to 1 the launch template will look like:
~~~
  # module.idp_launch_template.aws_launch_template.template will be updated in-place
  ~ resource "aws_launch_template" "template" {
      ~ image_id                             = "ami-074db07a0fa18f24a" -> "ami-00ca1bcc5c98da1af"
      ~ latest_version                       = 10 -> (known after apply)
      ~ user_data                            = "*"
      + instance_market_options {
          + market_type = "spot"
          + spot_options {
              + spot_instance_type = "one-time"
~~~