### PR TITLE
s3_batch_inventory: add S3 Inventory configs to all buckets in a list

### DIFF
--- a/s3_batch_inventory/README.md
+++ b/s3_batch_inventory/README.md
@@ -1,0 +1,69 @@
+# `s3_bucket_block`
+
+This Terraform module is designed to create an S3 bucket, or a set of buckets, from a map variable containing various bucket configurations. It provides consistency for the following, in all buckets provided:
+
+- Bucket naming scheme
+- Versioning enabled
+- Logging enabled
+- KMS SSE
+
+## Dynamic Settings
+
+By default, only the bucket's name is needed within the provided `bucket_data` map variable. This is built from:
+- `var.bucket_prefix`
+- `each.key` (in the `bucket_data` map variable)
+- `data.aws_caller_identity.current.account_id`
+- `var.region`
+
+The following additional settings can be configured via key-value pairs in the map:
+- `acl` (defaults to `private`)
+- `policy` (defaults to `""`)
+- `force_destroy` (defaults to `true`)
+- `lifecycle_rules` (list, defaults to `[]` and does not create any lifecycle rules unless provided)
+- `public_access_block` (defaults to `true`; creates an `aws_s3_bucket_public_access_block` resource for the accordant bucket)
+
+## Example
+
+```hcl
+module "s3_shared" {
+    source = "github.com/18F/identity-terraform//s3_bucket_block?ref=master"
+    
+    log_bucket = "login-gov.s3-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
+    bucket_prefix = "login-gov"
+    bucket_data = {
+        "shared-data" = {
+            policy = data.aws_iam_policy_document.shared.json
+        },
+        "lambda-functions" = {
+            policy          = data.aws_iam_policy_document.lambda-functions.json
+            lifecycle_rules = [
+                {
+                    id          = "inactive"
+                    enabled     = true
+                    prefix      = "/"
+                    transitions = [
+                        {
+                            days          = 180
+                            storage_class = "STANDARD_IA"
+                        }
+                    ]
+                }
+            ],
+            force_destroy = false
+        }, 
+        "waf-logs" = {},
+    }
+}
+```
+
+## Variables
+
+`bucket_prefix` - First substring in S3 bucket name of `$bucket_prefix.$bucket_name.$account_id-$region`
+`bucket_data` - Map of bucket names and their configuration blocks.
+`log_bucket` - Full name of the bucket used for S3 logging.
+`region` - AWS Region
+
+## Outputs
+
+`buckets` - A map of the format `var.bucket_data.each.key` => `aws_s3_bucket.bucket[*]["id"]` allowing one to obtain the full bucket name from the shorter key reference.
+

--- a/s3_batch_inventory/README.md
+++ b/s3_batch_inventory/README.md
@@ -1,69 +1,47 @@
-# `s3_bucket_block`
+# `s3_batch_inventory`
 
-This Terraform module is designed to create an S3 bucket, or a set of buckets, from a map variable containing various bucket configurations. It provides consistency for the following, in all buckets provided:
+This Terraform module is designed to add S3 Inventory configurations to all S3 buckets in a given list, as well as an S3 bucket to store the Inventory CSV files. Optionally, it can also create an S3 access log bucket, if one does not already exist, for the Inventory bucket.
 
-- Bucket naming scheme
-- Versioning enabled
-- Logging enabled
-- KMS SSE
+The Inventory filter is configured to include the following fields:
 
-## Dynamic Settings
+- `LastModifiedDate`
+- `ETag`
+- `EncryptionStatus`
 
-By default, only the bucket's name is needed within the provided `bucket_data` map variable. This is built from:
-- `var.bucket_prefix`
-- `each.key` (in the `bucket_data` map variable)
-- `data.aws_caller_identity.current.account_id`
-- `var.region`
+***Note:*** This was originally designed to retroactively add Inventory configs to older buckets (some created ad hoc as opposed to via Terraform), but can also be used in any case where the list of S3 buckets is static.
 
-The following additional settings can be configured via key-value pairs in the map:
-- `acl` (defaults to `private`)
-- `policy` (defaults to `""`)
-- `force_destroy` (defaults to `true`)
-- `lifecycle_rules` (list, defaults to `[]` and does not create any lifecycle rules unless provided)
-- `public_access_block` (defaults to `true`; creates an `aws_s3_bucket_public_access_block` resource for the accordant bucket)
+## Examples
 
-## Example
+Using a default region of `us-west-2`, with a log bucket already created:
 
 ```hcl
-module "s3_shared" {
-    source = "github.com/18F/identity-terraform//s3_bucket_block?ref=master"
-    
-    log_bucket = "login-gov.s3-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
-    bucket_prefix = "login-gov"
-    bucket_data = {
-        "shared-data" = {
-            policy = data.aws_iam_policy_document.shared.json
-        },
-        "lambda-functions" = {
-            policy          = data.aws_iam_policy_document.lambda-functions.json
-            lifecycle_rules = [
-                {
-                    id          = "inactive"
-                    enabled     = true
-                    prefix      = "/"
-                    transitions = [
-                        {
-                            days          = 180
-                            storage_class = "STANDARD_IA"
-                        }
-                    ]
-                }
-            ],
-            force_destroy = false
-        }, 
-        "waf-logs" = {},
-    }
+module "s3_inventory_uw2" {
+  source = "github.com/18F/identity-terraform//s3_batch_inventory?ref=master"
+
+  log_bucket   = "login-gov.s3-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
+  bucket_prefix = "login-gov"
+  bucket_list   = var.bucket_list_uw2
+}
+```
+
+Using a provider alias for `us-east-1`, allowing the module to create the log bucket:
+
+```
+module "s3_inventory_ue1" {
+  source = "github.com/18F/identity-terraform//s3_batch_inventory?ref=master"
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  region = "us-east-1"
+  bucket_prefix = "login-gov"
+  bucket_list   = var.bucket_list_ue1
 }
 ```
 
 ## Variables
 
-`bucket_prefix` - First substring in S3 bucket name of `$bucket_prefix.$bucket_name.$account_id-$region`
-`bucket_data` - Map of bucket names and their configuration blocks.
-`log_bucket` - Full name of the bucket used for S3 logging.
+`bucket_prefix` - First substring in S3 bucket name of `$bucket_prefix.s3-inventory.$account_id-$region`
+`bucket_list` - List of buckets (names only, *not* full ARNs) to have Inventory configurations added to them.
+`log_bucket` - Name of the bucket used for S3 logging. If left blank, the module will create one named `$bucket_prefix.s3-inv-logs.$account_id-$region`
 `region` - AWS Region
-
-## Outputs
-
-`buckets` - A map of the format `var.bucket_data.each.key` => `aws_s3_bucket.bucket[*]["id"]` allowing one to obtain the full bucket name from the shorter key reference.
-

--- a/s3_batch_inventory/README.md
+++ b/s3_batch_inventory/README.md
@@ -1,6 +1,6 @@
 # `s3_batch_inventory`
 
-This Terraform module is designed to add S3 Inventory configurations to all S3 buckets in a given list, as well as an S3 bucket to store the Inventory CSV files. Optionally, it can also create an S3 access log bucket, if one does not already exist, for the Inventory bucket.
+This Terraform module is designed to add S3 Inventory configurations to all S3 buckets in a given list, as well as an S3 bucket to store the Inventory CSV files.
 
 The Inventory filter is configured to include the following fields:
 
@@ -10,9 +10,7 @@ The Inventory filter is configured to include the following fields:
 
 ***Note:*** This was originally designed to retroactively add Inventory configs to older buckets (some created ad hoc as opposed to via Terraform), but can also be used in any case where the list of S3 buckets is static.
 
-## Examples
-
-Using a default region of `us-west-2`, with a log bucket already created:
+## Example
 
 ```hcl
 module "s3_inventory_uw2" {
@@ -24,24 +22,9 @@ module "s3_inventory_uw2" {
 }
 ```
 
-Using a provider alias for `us-east-1`, allowing the module to create the log bucket:
-
-```
-module "s3_inventory_ue1" {
-  source = "github.com/18F/identity-terraform//s3_batch_inventory?ref=master"
-  providers = {
-    aws = aws.us-east-1
-  }
-
-  region = "us-east-1"
-  bucket_prefix = "login-gov"
-  bucket_list   = var.bucket_list_ue1
-}
-```
-
 ## Variables
 
 `bucket_prefix` - First substring in S3 bucket name of `$bucket_prefix.s3-inventory.$account_id-$region`
 `bucket_list` - List of buckets (names only, *not* full ARNs) to have Inventory configurations added to them.
-`log_bucket` - Name of the bucket used for S3 logging. If left blank, the module will create one named `$bucket_prefix.s3-inv-logs.$account_id-$region`
+`log_bucket` - Name of the bucket used for S3 logging.
 `region` - AWS Region

--- a/s3_batch_inventory/main.tf
+++ b/s3_batch_inventory/main.tf
@@ -1,0 +1,102 @@
+# -- Variables --
+variable "bucket_prefix" {
+  description = "First substring in S3 bucket name of $bucket_prefix.s3-inventory.$account_id-$region"
+  type        = string
+}
+
+variable "bucket_list" {
+  description = "List of bucket names to have inventory configurations added to them."
+  type        = any
+  default     = {}
+}
+
+variable "log_bucket" {
+  description = "Name of the bucket used for S3 logging."
+  type        = string
+  default     = "s3-logs"
+}
+
+variable "region" {
+  default     = "us-west-2"
+  description = "AWS Region"
+}
+
+# -- Data Sources --
+data "aws_caller_identity" "current" {
+}
+
+data "aws_iam_policy_document" "inventory_bucket_policy" {
+  statement {
+    sid     = replace(statement.value, "/[.-]/", "")
+    actions = [
+      "s3:PutObject"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+    resources = [
+      "${var.bucket_prefix}.s3-inventory.${data.aws_caller_identity.current.account_id}-${var.region}/"
+    ]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = var.bucket_list
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}
+
+# -- Resources --
+
+resource "aws_s3_bucket" "inventory_bucket" {
+  bucket = "${var.bucket_prefix}.s3-inventory.${data.aws_caller_identity.current.account_id}-${var.region}"
+  region = var.region
+  force_destroy = true
+  policy = data.aws_iam_policy_document.inventory_bucket_policy
+
+  logging {
+    target_bucket = var.log_bucket
+    target_prefix = "${var.bucket_prefix}.s3-inventory.${data.aws_caller_identity.current.account_id}-${var.region}/"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_inventory" "daily_inventory" {
+  for_each = toset(var.bucket_list)
+
+  bucket = each.key
+  name = "FullBucketDailyInventory"
+  included_object_versions = "All"
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  destination {
+    bucket {
+      format     = "CSV"
+      bucket_arn = aws_s3_bucket.inventory.arn
+    }
+  }
+}


### PR DESCRIPTION
This Terraform module is designed to add S3 Inventory configurations to all S3 buckets in a given list, as well as an S3 bucket to store the Inventory CSV files. Optionally, it can also create an S3 access log bucket, if one does not already exist, for the Inventory bucket.

Full information available in the `README.md` file.