### PR TITLE
use variable to control SSE algorithm instead of hard-coding

### DIFF
--- a/s3_batch_inventory/main.tf
+++ b/s3_batch_inventory/main.tf
@@ -25,7 +25,7 @@ variable "region" {
 variable "sse_algorithm" {
   description = "SSE algorithm to use to encrypt reports."
   type        = string
-  default     = "AES256"
+  default     = "aws:kms"
 }
 
 # -- Data Sources --

--- a/s3_batch_inventory/main.tf
+++ b/s3_batch_inventory/main.tf
@@ -22,6 +22,12 @@ variable "region" {
   default     = "us-west-2"  
 }
 
+variable "sse_algorithm" {
+  description = "SSE algorithm to use to encrypt reports."
+  type        = string
+  default     = "AES256"
+}
+
 # -- Data Sources --
 data "aws_caller_identity" "current" {
 }
@@ -76,7 +82,7 @@ resource "aws_s3_bucket" "inventory" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
+        sse_algorithm = var.sse_algorithm
       }
     }
   }


### PR DESCRIPTION
Does what it says on the tin. Default sets to `AES256` instead, so that objects can be added without the need for a KMS CMK.