### PR TITLE
Add hard scale in option for recycle schedule

### DIFF
--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -13,6 +13,11 @@ variable "normal_desired_capacity" {
   description = ""
 }
 
+variable "override_spindown_capacity" {
+  description = "Set a specific number of instances for spindown instead of normal_desired_capacity"
+  default = -1
+}
+
 variable "max_size" {
   default = -1
 }
@@ -89,7 +94,7 @@ resource "aws_autoscaling_schedule" "spindown" {
   scheduled_action_name = "auto-recycle.spindown"
   min_size              = var.min_size
   max_size              = var.max_size
-  desired_capacity      = var.normal_desired_capacity
+  desired_capacity      = var.override_spindown_capacity == -1 ? var.normal_desired_capacity : var.override_spindown_capacity
   recurrence            = var.spindown_recurrence != "" ? var.spindown_recurrence : local.default_spindown_recurrence
 
   autoscaling_group_name = var.asg_name

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -43,10 +43,10 @@ variable "use_daily_business_hours_schedule" {
 
 # This block defines the actual default spinup/spindown schedule.
 # If use_daily_business_hours_schedule is enabled, from Mon-Fri spin up at 1700
-# UTC and spin down at 1800 UTC. Otherwise recycle every 6 hours every day by default.
+# UTC and spin down at 1730 UTC. Otherwise recycle every 6 hours every day by default.
 locals {
   default_spinup_recurrence   = var.use_daily_business_hours_schedule == 1 ? "0 17 * * 1-5" : "0 5,11,17,23 * * *"
-  default_spindown_recurrence = var.use_daily_business_hours_schedule == 1 ? "0 18 * * 1-5" : "0 6,12,18,0 * * *"
+  default_spindown_recurrence = var.use_daily_business_hours_schedule == 1 ? "30 17 * * 1-5" : "30 5,11,17,23 * * *"
 }
 
 # Default schedule unless spinup_recurrence / spindown_recurrence are overridden:


### PR DESCRIPTION
Adds `override_spindown_capacity` to force a specific spindown size.
Shrinks normal auto-recycle window to 30 minutes instead of 60.

Related to https://github.com/18F/identity-devops/issues/2846