### PR TITLE
adding block_public_access variable to disable block if desired

### DIFF
--- a/s3_config/README.md
+++ b/s3_config/README.md
@@ -28,3 +28,4 @@ module "secrets_bucket_config" {
 `region` - AWS Region
 `inventory_bucket_arn` - ARN of the S3 bucket used for collecting the S3 Inventory reports.
 `optional_fields` - List of optional data fields to collect in S3 Inventory reports. Defaults to the full list of possible fields.
+`block_public_access` - Whether or not to enable the public access block for this bucket. Defaults to ***true***.

--- a/s3_config/main.tf
+++ b/s3_config/main.tf
@@ -46,6 +46,12 @@ variable "optional_fields" {
   ]
 }
 
+variable "block_public_access" {
+  description = "Whether or not to enable the public access block for this bucket."
+  type        = bool
+  default     = true
+}
+
 locals {
   bucket_fullname = var.bucket_name_override != "" ? var.bucket_name_override : join(".",
     [
@@ -63,10 +69,10 @@ data "aws_caller_identity" "current" {
 # -- Resources --
 resource "aws_s3_bucket_public_access_block" "public_block" {
   bucket                  = local.bucket_fullname
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  block_public_acls       = var.block_public_access
+  block_public_policy     = var.block_public_access
+  ignore_public_acls      = var.block_public_access
+  restrict_public_buckets = var.block_public_access
 }
 
 resource "aws_s3_bucket_inventory" "daily" {


### PR DESCRIPTION
Does what it says on the tin. Will simply set the values of all public access block configs to `false` on the bucket the module is directed at.