### PR TITLE
updating all modules to work with version 3 of hashicorp/aws Terraform provider

### DIFF
--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -44,7 +44,7 @@ resource "aws_acm_certificate" "main" {
 
 # Create each validation CNAME
 resource "aws_route53_record" "validation-cnames" {
-  count = length(var.subject_alternative_names)
+  count = length(var.subject_alternative_names) + 1
 
   name    = aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_name"]
   type    = aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_type"]

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -4,12 +4,6 @@ variable "domain_name" {
   description = "The primary name used on the issued TLS certificate"
 }
 
-# TODO: convert to bool
-variable "enabled" {
-  default     = 1
-  description = "Like count, but for the whole module. 1 for True, 0 for False."
-}
-
 variable "subject_alternative_names" {
   default     = []
   description = "A list of additional names to add to the certificate"
@@ -27,53 +21,42 @@ variable "validation_cname_ttl" {
 
 output "cert_arn" {
   description = "ARN of the issued ACM certificate"
-  value       = element(concat(aws_acm_certificate.main.*.arn, [""]), 0)
+  value       = aws_acm_certificate.main.arn
 }
 
 output "finished_id" {
   description = "Reference this output in order to depend on validation being complete."
-  value       = element(concat(aws_acm_certificate_validation.main.*.id, [""]), 0)
+  value       = aws_acm_certificate_validation.main.id
 }
 
 # -- Resources --
 
 # Create the certificate with the specified SubjectAltNames
 resource "aws_acm_certificate" "main" {
-  count = var.enabled
-
   domain_name               = var.domain_name
   subject_alternative_names = var.subject_alternative_names
-
-  validation_method = "DNS"
+  validation_method         = "DNS"
 
   lifecycle {
     create_before_destroy = true
-
-    # TODO: this is a workaround for an AWS API / Terraform AWS provider bug
-    # https://github.com/terraform-providers/terraform-provider-aws/issues/8531
-    # https://github.com/18F/identity-devops/issues/1469
-    ignore_changes = [subject_alternative_names]
   }
 }
 
 # Create each validation CNAME
 resource "aws_route53_record" "validation-cnames" {
-  count = var.enabled == 1 ? length(var.subject_alternative_names) + 1 : 0
+  count = length(var.subject_alternative_names)
 
-  name    = aws_acm_certificate.main[0].domain_validation_options[count.index]["resource_record_name"]
-  type    = aws_acm_certificate.main[0].domain_validation_options[count.index]["resource_record_type"]
+  name    = aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_name"]
+  type    = aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_type"]
   zone_id = var.validation_zone_id
-  records = [aws_acm_certificate.main[0].domain_validation_options[count.index]["resource_record_value"]]
+  records = [aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_value"]]
   ttl     = var.validation_cname_ttl
 }
 
 # Synthetic Terraform resource that blocks on validation completion
 # You can depend_on this to wait for the ACM cert to be ready.
 resource "aws_acm_certificate_validation" "main" {
-  count = var.enabled
-
-  certificate_arn = aws_acm_certificate.main[0].arn
-
+  certificate_arn         = aws_acm_certificate.main.arn
   validation_record_fqdns = aws_route53_record.validation-cnames.*.fqdn
 }
 

--- a/acm_certificate/main.tf
+++ b/acm_certificate/main.tf
@@ -44,19 +44,26 @@ resource "aws_acm_certificate" "main" {
 
 # Create each validation CNAME
 resource "aws_route53_record" "validation-cnames" {
-  count = length(var.subject_alternative_names) + 1
+  for_each = {
+    for item in aws_acm_certificate.main.domain_validation_options: item.domain_name => {
+      name   = item.resource_record_name
+      record = item.resource_record_value
+      type   = item.resource_record_type
+    }
+  }
 
-  name    = aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_name"]
-  type    = aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_type"]
-  zone_id = var.validation_zone_id
-  records = [aws_acm_certificate.main.domain_validation_options[count.index]["resource_record_value"]]
-  ttl     = var.validation_cname_ttl
+  name            = each.value.name
+  type            = each.value.type
+  zone_id         = var.validation_zone_id
+  records         = [each.value.record]
+  ttl             = var.validation_cname_ttl
+  allow_overwrite = true
 }
 
 # Synthetic Terraform resource that blocks on validation completion
 # You can depend_on this to wait for the ACM cert to be ready.
 resource "aws_acm_certificate_validation" "main" {
   certificate_arn         = aws_acm_certificate.main.arn
-  validation_record_fqdns = aws_route53_record.validation-cnames.*.fqdn
+  validation_record_fqdns = [for record in aws_route53_record.validation-cnames: record.fqdn]
 }
 

--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -132,7 +132,7 @@ lifecycle_rule {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=b3e70684fbe69e14e6043290638b3e57194f12ac"
+  source = "github.com/18F/identity-terraform//s3_config?ref=5634690023ecb3e02180b4dbd49801e369bdbe57"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -21,6 +21,11 @@ variable "region" {
   description = "AWS Region"
 }
 
+variable "inventory_bucket_arn" {
+  description = "ARN of the S3 bucket used for collecting the S3 Inventory reports."
+  type        = string
+}
+
 # -- Data Sources --
 data "aws_caller_identity" "current" {
 }

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -26,6 +26,12 @@ variable "inventory_bucket_arn" {
   type        = string
 }
 
+variable "sse_algorithm" {
+  description = "SSE algorithm to use to encrypt reports in S3 Inventory bucket."
+  type        = string
+  default     = "aws:kms"
+}
+
 # -- Data Sources --
 data "aws_caller_identity" "current" {
 }

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -30,7 +30,6 @@ resource "aws_s3_bucket" "bucket" {
   for_each = var.bucket_data
 
   bucket = "${var.bucket_name_prefix}.${each.key}.${data.aws_caller_identity.current.account_id}-${var.region}"
-  region = var.region
   acl    = lookup(each.value, "acl", "private")
   policy = lookup(each.value, "policy", "")
   force_destroy = lookup(each.value, "force_destroy", true)

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -95,7 +95,7 @@ module "bucket_config" {
   bucket_name          = each.key
   region               = var.region
   inventory_bucket_arn = var.inventory_bucket_arn
-  block_public_access  = lookup(each.value, "public_access_block")
+  block_public_access  = lookup(each.value, "public_access_block", true)
 }
 
 # -- Outputs --

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -70,7 +70,6 @@ locals {
 # Bucket used for storing S3 access logs
 resource "aws_s3_bucket" "s3-logs" {
   bucket = local.log_bucket
-  region = var.region
   acl    = "log-delivery-write"
   policy = ""
 
@@ -117,7 +116,6 @@ resource "aws_s3_bucket" "tf-state" {
   count = var.remote_state_enabled
 
   bucket = local.state_bucket
-  region = var.region
   acl    = "private"
   policy = ""
   versioning {
@@ -167,7 +165,6 @@ resource "aws_dynamodb_table" "tf-lock-table" {
 # bucket to collect S3 Inventory reports
 resource "aws_s3_bucket" "inventory" {
   bucket        = local.inventory_bucket
-  region        = var.region
   force_destroy = true
   policy        = data.aws_iam_policy_document.inventory_bucket_policy.json
 


### PR DESCRIPTION
Does what it says on the tin!

This addresses numerous changes, most of which are explained in the [Terraform AWS Provider Version 3 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade). In particular, this also acknowledges [the fix for `domain_validation_options` in the `aws_acm_certificate` resource](https://github.com/terraform-providers/terraform-provider-aws/issues/8531#issuecomment-663562156), which is now read as an unordered set rather than an ordered list (negating the need for our hacky `ignore_changes` workaround!).