### PR TITLE
Resolve issue with KMS logging alarms

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -579,7 +579,7 @@ resource "aws_cloudwatch_metric_alarm" "dead_letter" {
   alarm_description  = "This alarm notifies when messages are on dead letter queue"
   treat_missing_data = "ignore"
   alarm_actions = [
-    var.sns_topic_dead_letter_arn,
+    var.alarm_sns_topic_arn,
   ]
 }
 
@@ -600,7 +600,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_lambda_backlog" {
   alarm_description  = "Kinesis backlog for ${var.env_name}-cloudwatch-kms"
   treat_missing_data = "ignore"
   alarm_actions = [
-    aws_sns_topic.kms_logging_events.arn,
+    var.alarm_sns_topic_arn,
   ]
 }
 
@@ -623,7 +623,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudtrail_lambda_backlog" {
   alarm_description  = "Kinesis backlog for ${var.env_name}-cloudtrail-kms"
   treat_missing_data = "ignore"
   alarm_actions = [
-    aws_sns_topic.kms_logging_events.arn,
+    var.alarm_sns_topic_arn,
   ]
 }
 

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -663,6 +663,16 @@ resource "aws_lambda_function" "cloudtrail_processor" {
   }
 }
 
+module "ct-processor-github-alerts" {
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=897cd9f749ead05a97b0f904a5dedfe83d9a9566"
+  
+  enabled              = 1
+  function_name        = local.ct_processor_lambda_name
+  alarm_actions        = [var.alarm_sns_topic_arn]
+  error_rate_threshold = 5 # percent
+  datapoints_to_alarm  = 5
+}
+
 resource "aws_lambda_event_source_mapping" "cloudtrail_processor" {
   event_source_arn = aws_sqs_queue.kms_ct_events.arn
   function_name    = aws_lambda_function.cloudtrail_processor.arn
@@ -838,6 +848,16 @@ resource "aws_lambda_function" "cloudwatch_processor" {
     source_repo = "https://github.com/18F/identity-lambda-functions"
     environment = var.env_name
   }
+}
+
+module "cw-processor-github-alerts" {
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=897cd9f749ead05a97b0f904a5dedfe83d9a9566"
+  
+  enabled              = 1
+  function_name        = local.cw_processor_lambda_name
+  alarm_actions        = [var.alarm_sns_topic_arn]
+  error_rate_threshold = 5 # percent
+  datapoints_to_alarm  = 5
 }
 
 resource "aws_lambda_event_source_mapping" "cloudwatch_processor" {

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -54,7 +54,7 @@ variable "sns_topic_dead_letter_arn" {
 }
 
 variable "lambda_identity_lambda_functions_gitrev" {
-  default     = "40a8d2e68705313599e972a1cf50fd5a897ecc45"
+  default     = "1815de9b0893548876138e7086391e210cc85813"
   description = "Initial gitrev of identity-lambda-functions to deploy (updated outside of terraform)"
 }
 
@@ -71,4 +71,8 @@ variable "kmslog_lambda_debug" {
 variable "ec2_kms_arns" {
   default     = []
   description = "ARN(s) of EC2 roles permitted access to KMS"
+}
+
+variable "alarm_sns_topic_arn" {
+  description = "SNS Topic ARN for alarms"
 }


### PR DESCRIPTION
Update default Lambda version for new deployments.
Set alarm sns topic to a valid topic.
Add alarms for Lambda failures
Issues https://github.com/18F/identity-devops/issues/3008

### After merge update identity-devops PR https://github.com/18F/identity-devops/pull/3011 with new sha