### PR TITLE
Deploy of new alarms failed update config

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -671,6 +671,7 @@ module "ct-processor-github-alerts" {
   alarm_actions        = [var.alarm_sns_topic_arn]
   error_rate_threshold = 5 # percent
   datapoints_to_alarm  = 5
+  evaluation_periods   = 5
 }
 
 resource "aws_lambda_event_source_mapping" "cloudtrail_processor" {
@@ -858,6 +859,7 @@ module "cw-processor-github-alerts" {
   alarm_actions        = [var.alarm_sns_topic_arn]
   error_rate_threshold = 5 # percent
   datapoints_to_alarm  = 5
+  evaluation_periods   = 5
 }
 
 resource "aws_lambda_event_source_mapping" "cloudwatch_processor" {


### PR DESCRIPTION
Deployment of new alarms failed.  Needed to add another variable to config.
Deployed to crissupb environment.
Related to issue https://github.com/18F/identity-devops/issues/3008

### Need to update identity-devops PR with gitref after merge