### PR TITLE
Fix issues with Slack notifications

### DIFF
--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -71,18 +71,16 @@ locals {
     slackUsername = os.environ['slack_username']
     slackIcon = os.environ['slack_icon']
     slackUrlParam = os.environ['slack_webhook_url_parameter']
+    parameter = ssm.get_parameter(Name=slackUrlParam, WithDecryption=True)
     http = urllib3.PoolManager()
     def lambda_handler(event, context):
-        parameter = ssm.get_parameter(Name=slackUrlParam, WithDecryption=True)
-        webhook_url = parameter['Parameter']['Value']
-        url = webhook_url
+        url = parameter['Parameter']['Value']
         msg = {
             "channel": slackChannel,
             "username": slackUsername,
             "text": event['Records'][0]['Sns']['Message'],
             "icon_emoji": slackIcon
         }
-        
         encoded_msg = json.dumps(msg).encode('utf-8')
         resp = http.request('POST',url, body=encoded_msg)
         print({

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -117,19 +117,19 @@ data "aws_iam_policy_document" "lambda_policy" {
       "logs:PutLogEvents"
     ]
     resources = [
-      aws_cloudwatch_log_group.slack_lambda.arn
+      "${aws_cloudwatch_log_group.slack_lambda.arn}:*"
     ]
   }
   statement {
-    sid     = "AllowCreateLogGroup"
-    effect  = "Allow"
+    sid    = "SSM"
+    effect = "Allow"
     actions = [
-      "logs:CreateLogGroup"
+      "ssm:DescribeParameters",
+      "ssm:GetParameter"
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.slack_webhook_url_parameter}"
     ]
-
   }
 }
 
@@ -146,7 +146,7 @@ data "archive_file" "lambda_function" {
 # -- Resources --
 
 resource "aws_cloudwatch_log_group" "slack_lambda" {
-  name              = "/aws/lambda/slack_lambda/${var.lambda_name}"
+  name              = "/aws/lambda/${var.lambda_name}"
   retention_in_days = 365
 }
 
@@ -165,9 +165,9 @@ resource "aws_lambda_function" "slack_lambda" {
   environment {
     variables = {
       slack_url_parameter = var.slack_webhook_url_parameter
-      slack_channel = var.slack_channel,
-      slack_username = var.slack_username,
-      slack_icon = var.slack_icon
+      slack_channel       = var.slack_channel,
+      slack_username      = var.slack_username,
+      slack_icon          = var.slack_icon
     }
   }
 }

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -162,10 +162,10 @@ resource "aws_lambda_function" "slack_lambda" {
 
   environment {
     variables = {
-      slack_url_parameter = var.slack_webhook_url_parameter
-      slack_channel       = var.slack_channel,
-      slack_username      = var.slack_username,
-      slack_icon          = var.slack_icon
+      slack_webhook_url_parameter = var.slack_webhook_url_parameter
+      slack_channel               = var.slack_channel,
+      slack_username              = var.slack_username,
+      slack_icon                  = var.slack_icon
     }
   }
 }


### PR DESCRIPTION
Pull slack webhook url from SSM parameter
Update CloudWatch log configuration
Update Lambda permissions
Related to issue https://github.com/18F/identity-security-private/issues/1809

Will need to update parameter /account/slack/webhook/url with Slack webhook url after deployment.
### Update PR in identity-devops with sha after merge