### PR TITLE
fixing dependencies for public access block/inventory on buckets

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -132,7 +132,7 @@ lifecycle_rule {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=897cd9f749ead05a97b0f904a5dedfe83d9a9566"
+  source = "github.com/18F/identity-terraform//s3_config?ref=cad9776e886147179d563a9b058b92b3dfbf3957"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -88,7 +88,7 @@ resource "aws_s3_bucket" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source = "github.com/18F/identity-terraform//s3_config?ref=897cd9f749ead05a97b0f904a5dedfe83d9a9566"
+  source = "github.com/18F/identity-terraform//s3_config?ref=cad9776e886147179d563a9b058b92b3dfbf3957"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/s3_config/main.tf
+++ b/s3_config/main.tf
@@ -76,6 +76,7 @@ resource "aws_s3_bucket_public_access_block" "public_block" {
 }
 
 resource "aws_s3_bucket_inventory" "daily" {
+  depends_on = [aws_s3_bucket_public_access_block.public_block]
   bucket                   = local.bucket_fullname
   name                     = "FullBucketDailyInventory"
   included_object_versions = "All"

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -199,6 +199,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 module "s3_config" {
   for_each = var.remote_state_enabled == 1 ? toset(["s3-logs", "tf-state"]) : toset(["s3-logs"])
   source = "github.com/18F/identity-terraform//s3_config?ref=cad9776e886147179d563a9b058b92b3dfbf3957"
+  depends_on = [aws_s3_bucket.s3-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -198,7 +198,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each = var.remote_state_enabled == 1 ? toset(["s3-logs", "tf-state"]) : toset(["s3-logs"])
-  source = "github.com/18F/identity-terraform//s3_config?ref=36ecdc74c3436585568fab7abddb3336cec35d93"
+  source = "github.com/18F/identity-terraform//s3_config?ref=cad9776e886147179d563a9b058b92b3dfbf3957"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key


### PR DESCRIPTION
Terraform doesn't understand that S3 operations can't be executed simultaneously on the same bucket -- in this case, the public access block and the S3 inventory config. This adds a few `depends_on` lines to make everything wait its turn.