### PR TITLE
removing null_resource dependency from squid_cloudwatch_filters

### DIFF
--- a/squid_cloudwatch_filters/main.tf
+++ b/squid_cloudwatch_filters/main.tf
@@ -13,7 +13,7 @@ variable "metric_namespace" {
 }
 
 variable "treat_missing_data" {
-  description = "How to treat missing metric data in the denials alarm. https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html#treat_missing_data"
+  description = "How to treat missing metric data in the denials alarm."
   default     = "breaching"
 }
 
@@ -26,14 +26,7 @@ locals {
   log_group_name = var.log_group_name_override == "" ? "${var.env_name}_/var/log/squid/access.log" : var.log_group_name_override
 }
 
-resource "null_resource" "log_group_found" {
-  triggers = {
-    log_group = local.log_group_name
-  }
-}
-
 resource "aws_cloudwatch_log_metric_filter" "squid_requests_total" {
-  depends_on     = [null_resource.log_group_found]
   name           = "${var.env_name}-squid-requests-total"
   pattern        = "" # all events
   log_group_name = local.log_group_name
@@ -46,7 +39,6 @@ resource "aws_cloudwatch_log_metric_filter" "squid_requests_total" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "squid_requests_denied" {
-  depends_on     = [null_resource.log_group_found]
   name           = "${var.env_name}-squid-requests-denied"
   pattern        = "\"DENIED\"" # logs containing DENIED anywhere
   log_group_name = local.log_group_name


### PR DESCRIPTION
Because Terraform modules can now be created with the `depends_on` conditional, the `log_group_found` null resource is no longer necessary. Additionally, said null resource has, traditionally, operated inconsistently with environment builds/teardowns; using `depends_on` directly with the module declaration has instead provided accurate consistency in deployments.