### PR TITLE
Add permissions to Codebuild role

### DIFF
--- a/lambda_pipeline/codebuild.tf
+++ b/lambda_pipeline/codebuild.tf
@@ -415,7 +415,7 @@ data "aws_iam_policy_document" "codebuild_lambda" {
 
 data "aws_iam_policy_document" "codebuild_ssm" {
   statement {
-    sid    = "iam"
+    sid    = "ssm"
     effect = "Allow"
     actions = [
       "ssm:PutParameter",

--- a/lambda_pipeline/codebuild.tf
+++ b/lambda_pipeline/codebuild.tf
@@ -426,7 +426,8 @@ data "aws_iam_policy_document" "codebuild_ssm" {
       "ssm:DeleteParameter"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${var.env}/*"
+      "arn:${data.aws_partition.current.partition}:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${var.env}/*",
+      "arn:${data.aws_partition.current.partition}:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/account/*"
     ]
   }
 }


### PR DESCRIPTION
Codebuild cannot read the /account SSM parameters that are used to create Lambda functions.
Issue https://github.com/18F/identity-devops/issues/2989
### Update identity-devops PR https://github.com/18F/identity-devops/pull/3089 with new gitref after merge