### PR TITLE
Add alarm for pipeline stage failure

### DIFF
--- a/lambda_pipeline/variables.tf
+++ b/lambda_pipeline/variables.tf
@@ -52,3 +52,8 @@ variable "vpc_arn" {
   description = "VPC arn for functions that require vpc access"
   type        = string
 }
+
+variable "pipeline_failure_notification_arn" {
+  description = "SNS topic arn for pipeline failure notification"
+  type        = string
+}


### PR DESCRIPTION
CloudWatch event and notification on Codepipeline stage failure.
Issue https://github.com/18F/identity-devops/issues/3045

### Update identity-devops PR with sha after merge