### PR TITLE
changing name_prefix to name to avoid name constraints

### DIFF
--- a/lambda_pipeline/codepipeline.tf
+++ b/lambda_pipeline/codepipeline.tf
@@ -265,7 +265,7 @@ data "aws_iam_policy_document" "codepipeline_base" {
 }
 
 resource "aws_cloudwatch_event_rule" "lambda_pipeline_failed" {
-  name_prefix   = "${var.env}-${var.project_name}-pipeline-failed"
+  name          = "${var.env}-${var.project_name}-pipeline-failed"
   description   = "CodePipeline execution failed"
   event_pattern = <<EOF
 {


### PR DESCRIPTION
The name for the CloudWatch event rule `lambda_pipeline_failed` is currently generated using `name_prefix`; however, if the environment name + project name + 'pipeline-failed' + <generated CloudFormation numerical string> is greater than 64 characters, the rule cannot be created.

This changes the resource to name itself using `name`, instead of `name_prefix`. 