### PR TITLE
Don't publish new version of Slack lambda

### DIFF
--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -158,7 +158,7 @@ resource "aws_lambda_function" "slack_lambda" {
   timeout          = var.lambda_timeout
   memory_size      = var.lambda_memory
   source_code_hash = data.archive_file.lambda_function.output_base64sha256
-  publish          = true
+  publish          = false
 
   environment {
     variables = {


### PR DESCRIPTION
No need for versions. Notifications are using $Latest.

### Update identity-devops PR https://github.com/18F/identity-devops/pull/3115 with sha after merge