### PR TITLE
Prod - add s3 MFA delete for s3-logs and tf-state

### DIFF
--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -75,6 +75,7 @@ resource "aws_s3_bucket" "s3-logs" {
 
   versioning {
     enabled = true
+    mfa_delete = var.env_name == "prod" ? true : false
   }
 
   lifecycle_rule {
@@ -120,6 +121,7 @@ resource "aws_s3_bucket" "tf-state" {
   policy = ""
   versioning {
     enabled = true
+    mfa_delete = var.env_name == "prod" ? true : false
   }
 
   logging {

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -75,7 +75,7 @@ resource "aws_s3_bucket" "s3-logs" {
 
   versioning {
     enabled = true
-    mfa_delete = var.env_name == "prod" ? true : false
+    mfa_delete = var.s3_env
   }
 
   lifecycle_rule {
@@ -121,7 +121,7 @@ resource "aws_s3_bucket" "tf-state" {
   policy = ""
   versioning {
     enabled = true
-    mfa_delete = var.env_name == "prod" ? true : false
+    mfa_delete = var.s3_env
   }
 
   logging {

--- a/state_bucket/variables.tf
+++ b/state_bucket/variables.tf
@@ -1,0 +1,5 @@
+variable "s3_env" {
+  description = "Environment where the s3 bucket is being deployed (sandbox/stage/prod)"
+  type        = string
+  default     = "false"
+}


### PR DESCRIPTION
Prod Account Only: https://github.com/18F/identity-devops/issues/3210

As a login.gov user,
I would like to know that S3 access logs can not be deleted,
So that I can trust the audit trail and ability to investigate a breach of or attack on login.gov.

This is for s3-logs and tf-state bucket.