### PR TITLE
Require imdsv2

### DIFF
--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -84,7 +84,7 @@ resource "aws_launch_template" "template" {
 
   metadata_options {
     http_endpoint = "enabled"
-    http_tokens = "optional"
+    http_tokens = "required"
   }
 
   monitoring {


### PR DESCRIPTION
Require use of instance metadata service v2.
Issue https://github.com/18F/identity-devops/issues/2948
### Update identity-devops PR https://github.com/18F/identity-devops/pull/3504 launch templates with gitsha after merge.