### PR TITLE
Create new s3 access logs bucket

### DIFF
--- a/s3_batch_inventory/README.md
+++ b/s3_batch_inventory/README.md
@@ -14,7 +14,7 @@ This Terraform module is designed to add S3 Inventory configurations to all S3 b
 module "s3_inventory_uw2" {
   source = "github.com/18F/identity-terraform//s3_batch_inventory?ref=master"
 
-  log_bucket   = "login-gov.s3-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
+  log_bucket   = "login-gov.s3-access-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
   bucket_prefix = "login-gov"
   bucket_list   = var.bucket_list_uw2
 }

--- a/s3_bucket_block/README.md
+++ b/s3_bucket_block/README.md
@@ -30,7 +30,7 @@ The following additional settings can be configured via key-value pairs in the m
 module "s3_shared" {
     source = "github.com/18F/identity-terraform//s3_bucket_block?ref=master"
     
-    log_bucket         = "login-gov.s3-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
+    log_bucket         = "login-gov.s3-access-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
     bucket_name_prefix = "login-gov"
     bucket_data        = {
         "shared-data"      = {

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -13,7 +13,7 @@ variable "bucket_data" {
 variable "log_bucket" {
   description = "Name of the bucket used for S3 logging."
   type        = string
-  default     = "s3-logs"
+  default     = "s3-access-logs"
 }
 
 variable "region" {


### PR DESCRIPTION
Related to issue https://github.com/18F/identity-devops/issues/3466
Create new s3 access logs bucket.  This bucket will replace existing bucket.  Configure lifecycle policy to clear out existing bucket to facilitate deletion in the following release.  Not feasible to write a policy clears out the existing data while writing new data to the bucket.

### Will need to update identity-devops PR https://github.com/18F/identity-devops/pull/3558 with updated gitref after merging.
