### PR TITLE
Updates to Lambda Pipeline

### DIFF
--- a/lambda_pipeline/codecommit.tf
+++ b/lambda_pipeline/codecommit.tf
@@ -1,0 +1,5 @@
+resource "aws_codecommit_repository" "buildspec" {
+    count = var.build_account == data.aws_caller_identity.current.account_id ? 1 : 0
+    repository_name = local.build_project_name
+    description     = "Repository for buildspec.yml"
+}

--- a/lambda_pipeline/codepipeline.tf
+++ b/lambda_pipeline/codepipeline.tf
@@ -8,10 +8,29 @@ resource "aws_codepipeline" "lambda" {
   }
 
   stage {
-    name = "Source"
+    name = "BuildSpec Source"
 
     action {
-      name             = "Source"
+      name             = "BuildSpecSource"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeCommit"
+      version          = "1"
+      output_artifacts = ["source_output"]
+
+      configuration = {
+        PollForSourceChanges = "false"
+        RepositoryName       = local.build_project_name
+        BranchName           = "main"
+      }
+    }
+  }
+
+  stage {
+    name = "Application Source"
+
+    action {
+      name             = "ApplicationSource"
       category         = "Source"
       owner            = "AWS"
       provider         = "S3"
@@ -26,6 +45,7 @@ resource "aws_codepipeline" "lambda" {
     }
   }
 
+s3://login-gov.lambda-functions.894947205914-us-west-2/circleci/identity-infra-functions/main/identity-infra-functions.zip
   stage {
     name = "Deploy"
 

--- a/lambda_pipeline/variables.tf
+++ b/lambda_pipeline/variables.tf
@@ -1,3 +1,13 @@
+variable build_account {
+  description = "Build Acccount Id"
+  type = string
+}
+
+variable shared_accounts {
+  description = "List of accounts to share artifacts with"
+  type = list
+  default = []
+}
 variable "region" {
   description = "AWS Region"
   type        = string


### PR DESCRIPTION
This is the beginning of work to update the Lambda pipeline so that we could deploy to production.  
Concepts
CircleCi zips up repo and copies to S3.
Build in single account either Sandbox or Tooling.
Copy the 2 artifacts to S3.  The generated CloudFormation template and the zip file with the code and libraries that is packaged using the SAM tool.
The buildspec.yml for building and deploying cannot reside in a public repository.
The buildspec.yml can either be kept in a separate CodeCommit repo or in the identity-devops repo and passed as a variable to the module and configure it inline with CodeBuild.
Share the S3 artifact bucket with the Prod account.
Create a pipeline that will be deployed to Prod that only runs the deploy and requires manual approval before running.

The AWS SAM tool is used to package and deploy.

This is a WIP and needs work and testing before it is ready to merge.