### PR TITLE
git2s3_artifacts: cross-account availability for third-party code repo importing

### DIFF
--- a/git2s3_artifacts/README.md
+++ b/git2s3_artifacts/README.md
@@ -1,0 +1,14 @@
+# `state_bucket`
+
+This module manages the terraform remote state S3 bucket and remote state
+DynamoDB lock table. These are tricky resources to manage because there is a
+chicken and egg bootstrapping problem involved in creating them. Terraform
+needs the remote state bucket to exist before it runs for the first time. But
+we also do want to manage this bucket in terraform so that it doesn't diverge
+from the expected configuration (encryption, versioning, etc.).
+
+For bootstrapping, the remote state bucket will be automatically created by
+`bin/tf-deploy` using `bin/configure_state_bucket.sh`. Then, import those
+resources into terraform for management by running the `terraform import`
+commands found in comments in [./main.tf](./main.tf).
+

--- a/git2s3_artifacts/README.md
+++ b/git2s3_artifacts/README.md
@@ -1,3 +1,69 @@
 # `git2s3_artifacts`
 
-TBD
+This Terraform module is a wrapper around the ["Git webhooks on the AWS Cloud" Quick Start Deployment](https://aws-quickstart.github.io/quickstart-git2s3/), a CloudFormation stack, here used as the resource `aws_cloudformation_stack.git2s3`. The Stack builds the necessary architecture -- an API gateway, Lambda function, S3 buckets, etc. -- for `git push` operations to trigger a retrieval, zip, and S3 upload of a given third-party repository.
+
+In addition to the original deployment Stack, this builds:
+
+1. A `public-artifacts` S3 bucket, which is accessible by resources in the AWS account where it is created, and by resources in any other AWS accounts specified with the `external_account_ids` list variable.
+2. A key, `git2s3/OutputBucketName`, within the `public-artifacts` bucket. Its content is the name of the S3 bucket `OutputBucket`, which is created by the `git2s3` Stack as the upload destination for the repository zips.
+
+This module can be used in cases where multiple AWS accounts need access to the code from a particular third-party repo, but one or more of those accounts is unable/not permitted to communicate with third-party services, such as GitHub; thus, it/they must be able to retrieve it from an AWS resource within the same organization/ownership boundary.
+
+## Note
+
+For the purposes of this module, the CloudFormation stack builds with its parameters hard-coded thusly:
+
+```
+    AllowedIps          = regex(
+                            "^[0-9.,\\/]+\\/32",
+                            substr(join(",",data.github_ip_ranges.ips.git), 0, 512)
+                          )
+    QSS3BucketName      = "aws-quickstart"
+    OutputBucketName    = ""
+    ScmHostnameOverride = ""
+    ExcludeGit          = "True"
+    VPCId               = ""
+    CustomDomainName    = ""
+    QSS3BucketRegion    = "us-east-1"
+    ApiSecret           = ""
+    QSS3KeyPrefix       = "quickstart-git2s3/"
+    VPCCidrRange        = ""
+    SubnetIds           = ""
+```
+
+The `regex()` string operation is used to trim down the list of IP addresses from the `github_ip_ranges.ips.git` data source, as explained below:
+
+1. By default, the list begins with larger ranges (e.g. `/20`, `/22`, etc.), and then contains a large array of individual `/32` addresses. At the time of this writing, the resulting string -- with commas joining the addresses -- is ~592 characters in length.
+2. The `AllowedIps` parameter is used within the CloudFormation stack to configure the AWS API Gateway resource, specifying the source IP ranges that the API will accept requests from. However, this `$stageVariable` must be *512 characters or less*; as the default list of IP ranges is larger than this, CloudFormation will refuse to accept it as an input parameter.
+3. To ensure that the resultant string for `AllowedIps` is under 512 characters, the comma-separated list of IPs created via `join()` is trimmed down to 512 characters by the `substr()` function; the `regex()` operation takes that resultant string and truncates it after the last `/32` address, ensuring that there won't be any partial addresses which would cause syntax errors.
+
+## Example
+
+```hcl
+module "git2s3_src" {
+  source = "github.com/18F/identity-terraform//git2s3_artifacts?ref=main"
+
+  git2s3_stack_name    = "CodeSync-IdentityBase"
+  external_account_ids = [
+    "000011112222",
+    "333344445555",
+    "666677778888",
+  ]
+  bucket_name_prefix = "login-gov"
+}
+
+module "main" {
+  source     = "../module"
+  depends_on = [module.git2s3_src.output_bucket]
+}
+```
+
+## Variables
+
+- `bucket_name_prefix` - **string**: REQUIRED. First substring in names for log_bucket, inventory_bucket, and the public-artifacts bucket.
+- `log_bucket_name` - **string**: (OPTIONAL) Specific name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.
+- `region` - **string**: AWS Region. Defaults to `us-west-2`.
+- `inventory_bucket_name` - **string**: (OPTIONAL) Specific name of the S3 bucket used for collecting the S3 Inventory reports. Will default to `$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared.
+- `sse_algorithm` - **string**: SSE algorithm to use to encrypt reports in S3 Inventory bucket. Defaults to `aws:kms`.
+- `git2s3_stack_name` - **string**: REQUIRED. Name for the `git2s3` CloudFormation Stack.
+- `external_account_ids` - **list(string)**: (OPTIONAL) List of additional AWS account IDs, if any, to be permitted access to the public-artifacts bucket.

--- a/git2s3_artifacts/README.md
+++ b/git2s3_artifacts/README.md
@@ -1,14 +1,3 @@
-# `state_bucket`
+# `git2s3_artifacts`
 
-This module manages the terraform remote state S3 bucket and remote state
-DynamoDB lock table. These are tricky resources to manage because there is a
-chicken and egg bootstrapping problem involved in creating them. Terraform
-needs the remote state bucket to exist before it runs for the first time. But
-we also do want to manage this bucket in terraform so that it doesn't diverge
-from the expected configuration (encryption, versioning, etc.).
-
-For bootstrapping, the remote state bucket will be automatically created by
-`bin/tf-deploy` using `bin/configure_state_bucket.sh`. Then, import those
-resources into terraform for management by running the `terraform import`
-commands found in comments in [./main.tf](./main.tf).
-
+TBD

--- a/git2s3_artifacts/git2s3.template
+++ b/git2s3_artifacts/git2s3.template
@@ -1,0 +1,1612 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Git webhooks to clone and store a Git repository in S3. Used to integrate Git services with AWS services like AWS CodePipeline, AWS CodeBuild, and AWS CodeDeploy. (qs-1nfhrd9bh)",
+    "Metadata": {
+        "QuickStartDocumentation": {
+            "EntrypointName": "Parameters for deploying into your selected Region"
+        },
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "General settings"
+                    },
+                    "Parameters": [
+                        "OutputBucketName",
+                        "CustomDomainName"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Git pull settings"
+                    },
+                    "Parameters": [
+                        "ApiSecret",
+                        "AllowedIps",
+                        "ExcludeGit"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "AWS Quick Start configuration"
+                    },
+                    "Parameters": [
+                        "QSS3BucketName",
+                        "QSS3BucketRegion",
+                        "QSS3KeyPrefix"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "VPC configuration"
+                    },
+                    "Parameters": [
+                        "VPCId",
+                        "VPCCidrRange",
+                        "SubnetIds",
+                        "ScmHostnameOverride"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "AllowedIps": {
+                    "default": "Allowed IP addresses"
+                },
+                "ApiSecret": {
+                    "default": "API secret"
+                },
+                "CustomDomainName": {
+                    "default": "Custom domain name"
+                },
+                "OutputBucketName": {
+                    "default": "Output S3 bucket name"
+                },
+                "QSS3BucketName": {
+                    "default": "Quick Start S3 bucket name"
+                },
+                "QSS3BucketRegion": {
+                    "default": "Quick Start S3 bucket Region"
+                },
+                "QSS3KeyPrefix": {
+                    "default": "Quick Start S3 key prefix"
+                },
+                "VPCId": {
+                    "default": "VPC ID"
+                },
+                "VPCCidrRange": {
+                    "default": "VPC CIDR"
+                },
+                "SubnetIds": {
+                    "default": "Subnet IDs"
+                },
+                "ScmHostnameOverride": {
+                    "default": "Hostname override"
+                },
+                "ExcludeGit": {
+                    "default": "Exclude .git directory"
+                }
+            }
+        }
+    },
+    "Parameters": {
+        "AllowedIps": {
+            "Description": "Comma-separated list of allowed IP CIDR blocks. The default addresses listed are BitBucket Cloud IP ranges.",
+            "Type": "String",
+            "Default": "18.205.93.0/25,18.234.32.128/25,13.52.5.0/25"
+        },
+        "ApiSecret": {
+            "Description": "API secret used to authenticate access to webhooks in GitHub Enterprise, GitLab, and other Git services. If a webhook payload header contains a matching secret, IP address authentication is bypassed. API secrets cannot contain commas (,), backward slashes (\\), or quotes (\").",
+            "Type": "String",
+            "Default": "",
+            "NoEcho": "true"
+        },
+        "CustomDomainName": {
+            "Description": "Domain name for the webhook endpoint. If left blank, API Gateway creates a domain name for you.",
+            "Type": "String",
+            "Default": ""
+        },
+        "OutputBucketName": {
+            "Description": "(Optional) Name for the S3 bucket where the Git repository .zip file is stored. If left blank, the Quick Start creates one for you.",
+            "Type": "String",
+            "Default": ""
+        },
+        "QSS3BucketName": {
+            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
+            "ConstraintDescription": "Quick Start S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
+            "Default": "aws-quickstart",
+            "Description": "S3 bucket name for Quick Start assets. It can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
+            "Type": "String"
+        },
+        "QSS3BucketRegion": {
+            "Default": "us-east-1",
+            "Description": "AWS Region where the Quick Start assets S3 bucket (QSS3BucketName) is hosted. Required when using your own S3 bucket.",
+            "Type": "String"
+        },
+        "QSS3KeyPrefix": {
+            "AllowedPattern": "^[0-9a-zA-Z-/]*$",
+            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slashes (/).",
+            "Default": "quickstart-git2s3/",
+            "Description": "Key prefix for the Quick Start assets S3 bucket. A key prefix is similar to a directory name that enables you to store similar data under the same directory in an S3 bucket. It can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slashes (/).",
+            "Type": "String"
+        },
+        "VPCId": {
+            "Description": "ID of the VPC in which the Lambda function runs.",
+            "Type": "String",
+            "Default": ""
+        },
+        "VPCCidrRange": {
+            "Description": "CIDR range of the VPC.",
+            "Type": "String",
+            "Default": ""
+        },
+        "SubnetIds": {
+            "Description": "SubnetIDs in which the Lambda function runs.",
+            "Type": "CommaDelimitedList",
+            "Default": ""
+        },
+        "ScmHostnameOverride": {
+            "Description": "Name to override the hostname in the header of a webhook JSON payload.",
+            "Type": "String",
+            "Default": ""
+        },
+        "ExcludeGit": {
+            "Description": "Choose False to omit the .git directory from the Git repository .zip file.",
+            "Type": "String",
+            "Default": "True",
+            "AllowedValues": [
+                "True",
+                "False"
+            ]
+        }
+    },
+    "Conditions": {
+        "UseAllowedIps": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AllowedIps"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseApiSecret": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "ApiSecret"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseCustomDomain": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "CustomDomainName"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "AutoGenOutputBucketName": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "OutputBucketName"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "ShouldRunInVPC": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "VPCId"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UsingDefaultBucket": {
+            "Fn::Equals": [
+                {
+                    "Ref": "QSS3BucketName"
+                },
+                "aws-quickstart"
+            ]
+        }
+    },
+    "Resources": {
+        "LambdaZipsBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+                "Tags": []
+            }
+        },
+        "CopyZips": {
+            "Type": "AWS::CloudFormation::CustomResource",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CopyZipsFunction",
+                        "Arn"
+                    ]
+                },
+                "DestBucket": {
+                    "Ref": "LambdaZipsBucket"
+                },
+                "SourceBucket": {
+                    "Fn::If": [
+                        "UsingDefaultBucket",
+                        {
+                            "Fn::Sub": "${QSS3BucketName}-${AWS::Region}"
+                        },
+                        {
+                            "Ref": "QSS3BucketName"
+                        }
+                    ]
+                },
+                "Prefix": {
+                    "Ref": "QSS3KeyPrefix"
+                },
+                "Objects": [
+                    "functions/packages/CreateSSHKey/lambda.zip",
+                    "functions/packages/DeleteBucketContents/lambda.zip",
+                    "functions/packages/GitPullS3/lambda.zip"
+                ]
+            }
+        },
+        "CopyZipsRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                ],
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "lambda-copier",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetObject"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": [
+                                            "arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*",
+                                            {
+                                                "S3Bucket": {
+                                                    "Fn::If": [
+                                                        "UsingDefaultBucket",
+                                                        {
+                                                            "Fn::Sub": "${QSS3BucketName}-${AWS::Region}"
+                                                        },
+                                                        {
+                                                            "Ref": "QSS3BucketName"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:PutObject",
+                                        "s3:DeleteObject"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:aws:s3:::${LambdaZipsBucket}/${QSS3KeyPrefix}*"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:*"
+                                    ],
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "CopyZipsFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Description": "Copies objects from a source S3 bucket to a destination.",
+                "Handler": "index.handler",
+                "Runtime": "python3.7",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "CopyZipsRole",
+                        "Arn"
+                    ]
+                },
+                "Timeout": 240,
+                "Code": {
+                    "ZipFile": {
+                        "Fn::Join": [
+                            "\n",
+                            [
+                                "import json",
+                                "import logging",
+                                "import threading",
+                                "import boto3",
+                                "import cfnresponse",
+                                "",
+                                "",
+                                "def copy_objects(source_bucket, dest_bucket, prefix, objects):",
+                                "    s3 = boto3.client('s3')",
+                                "    for o in objects:",
+                                "        key = prefix + o",
+                                "        copy_source = {",
+                                "            'Bucket': source_bucket,",
+                                "            'Key': key",
+                                "        }",
+                                "        s3.copy_object(CopySource=copy_source, Bucket=dest_bucket, Key=key)",
+                                "",
+                                "",
+                                "def delete_objects(bucket, prefix, objects):",
+                                "    s3 = boto3.client('s3')",
+                                "    objects = {'Objects': [{'Key': prefix + o} for o in objects]}",
+                                "    s3.delete_objects(Bucket=bucket, Delete=objects)",
+                                "",
+                                "",
+                                "def timeout(event, context):",
+                                "    logging.error('Execution is about to time out, sending failure response to CloudFormation')",
+                                "    cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)",
+                                "",
+                                "",
+                                "def handler(event, context):",
+                                "    # make sure we send a failure to CloudFormation if the function is going to timeout",
+                                "    timer = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5, timeout, args=[event, context])",
+                                "    timer.start()",
+                                "",
+                                "    print('Received event: %s' % json.dumps(event))",
+                                "    status = cfnresponse.SUCCESS",
+                                "    try:",
+                                "        source_bucket = event['ResourceProperties']['SourceBucket']",
+                                "        dest_bucket = event['ResourceProperties']['DestBucket']",
+                                "        prefix = event['ResourceProperties']['Prefix']",
+                                "        objects = event['ResourceProperties']['Objects']",
+                                "        if event['RequestType'] == 'Delete':",
+                                "            delete_objects(dest_bucket, prefix, objects)",
+                                "        else:",
+                                "            copy_objects(source_bucket, dest_bucket, prefix, objects)",
+                                "    except Exception as e:",
+                                "        logging.error('Exception: %s' % e, exc_info=True)",
+                                "        status = cfnresponse.FAILED",
+                                "    finally:",
+                                "        timer.cancel()",
+                                "        cfnresponse.send(event, context, status, {}, None)",
+                                ""
+                            ]
+                        ]
+                    }
+                }
+            }
+        },
+        "KeyBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+                "Tags": []
+            }
+        },
+        "OutputBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+                "BucketName": {
+                    "Fn::If": [
+                        "AutoGenOutputBucketName",
+                        {
+                            "Ref": "OutputBucketName"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                },
+                "Tags": []
+            }
+        },
+        "KMSKey": {
+            "Type": "AWS::KMS::Key",
+            "Properties": {
+                "Description": "AWS KWS key to encrypt and decrypt SSH keys stored in S3.",
+                "KeyPolicy": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "Allow access for Key Administrators",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": [
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:aws:iam::",
+                                                {
+                                                    "Ref": "AWS::AccountId"
+                                                },
+                                                ":root"
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            },
+                            "Action": [
+                                "kms:Create*",
+                                "kms:Describe*",
+                                "kms:Enable*",
+                                "kms:List*",
+                                "kms:Put*",
+                                "kms:Update*",
+                                "kms:Revoke*",
+                                "kms:Disable*",
+                                "kms:Get*",
+                                "kms:Delete*",
+                                "kms:ScheduleKeyDeletion",
+                                "kms:CancelKeyDeletion"
+                            ],
+                            "Resource": "*"
+                        },
+                        {
+                            "Sid": "Allow use of the key",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": [
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:aws:iam::",
+                                                {
+                                                    "Ref": "AWS::AccountId"
+                                                },
+                                                ":root"
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            },
+                            "Action": [
+                                "kms:Encrypt",
+                                "kms:Decrypt",
+                                "kms:ReEncrypt*",
+                                "kms:GenerateDataKey*",
+                                "kms:DescribeKey"
+                            ],
+                            "Resource": "*"
+                        },
+                        {
+                            "Sid": "Allow attachment of persistent resources",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": [
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:aws:iam::",
+                                                {
+                                                    "Ref": "AWS::AccountId"
+                                                },
+                                                ":root"
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            },
+                            "Action": [
+                                "kms:CreateGrant",
+                                "kms:ListGrants",
+                                "kms:RevokeGrant"
+                            ],
+                            "Resource": "*",
+                            "Condition": {
+                                "Bool": {
+                                    "kms:GrantIsForAWSResource": true
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "CreateSSHKeyRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "git2cp-sshkeygen",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetObject"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "KeyBucket"
+                                                    },
+                                                    "/crypto.zip"
+                                                ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:PutObject"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "KeyBucket"
+                                                    },
+                                                    "/enc_key"
+                                                ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "kms:Encrypt"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "KMSKey",
+                                                "Arn"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        "arn:aws:logs:*:*:*"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "CreateSSHKeyLambda": {
+            "DependsOn": "CopyZips",
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Handler": "lambda_function.lambda_handler",
+                "MemorySize": 128,
+                "Role": {
+                    "Fn::GetAtt": [
+                        "CreateSSHKeyRole",
+                        "Arn"
+                    ]
+                },
+                "Runtime": "python3.8",
+                "Timeout": 300,
+                "Code": {
+                    "S3Bucket": {
+                        "Ref": "LambdaZipsBucket"
+                    },
+                    "S3Key": {
+                        "Fn::Sub": "${QSS3KeyPrefix}functions/packages/CreateSSHKey/lambda.zip"
+                    }
+                }
+            }
+        },
+        "CreateSSHKey": {
+            "Type": "AWS::CloudFormation::CustomResource",
+            "Version": "1.0",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CreateSSHKeyLambda",
+                        "Arn"
+                    ]
+                },
+                "KeyBucket": {
+                    "Ref": "KeyBucket"
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "KMSKey": {
+                    "Ref": "KMSKey"
+                }
+            }
+        },
+        "DeleteBucketContentsRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "git2cp-deletebucketcontents",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:*"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "KeyBucket"
+                                                    },
+                                                    "/*"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "OutputBucket"
+                                                    },
+                                                    "/*"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "KeyBucket"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "OutputBucket"
+                                                    }
+                                                ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        "arn:aws:logs:*:*:*"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "DeleteBucketContentsLambda": {
+            "DependsOn": "CopyZips",
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Handler": "lambda_function.lambda_handler",
+                "MemorySize": 128,
+                "Role": {
+                    "Fn::GetAtt": [
+                        "DeleteBucketContentsRole",
+                        "Arn"
+                    ]
+                },
+                "Runtime": "python3.8",
+                "Timeout": 300,
+                "Code": {
+                    "S3Bucket": {
+                        "Ref": "LambdaZipsBucket"
+                    },
+                    "S3Key": {
+                        "Fn::Sub": "${QSS3KeyPrefix}functions/packages/DeleteBucketContents/lambda.zip"
+                    }
+                }
+            }
+        },
+        "DeleteBucketContents": {
+            "Type": "AWS::CloudFormation::CustomResource",
+            "Version": "1.0",
+            "DependsOn": [
+                "KeyBucket",
+                "OutputBucket"
+            ],
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "DeleteBucketContentsLambda",
+                        "Arn"
+                    ]
+                },
+                "KeyBucket": {
+                    "Ref": "KeyBucket"
+                },
+                "OutputBucket": {
+                    "Ref": "OutputBucket"
+                }
+            }
+        },
+        "CodeBuildServiceRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "codebuild.amazonaws.com"
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "ManagedPolicyArns": [
+                    {
+                        "Ref": "CodeBuildEndpointPolicy"
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "tagging-policy",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    "test",
+                                    "ok"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "CodeBuildBasePolicy": {
+            "Type": "AWS::IAM::ManagedPolicy",
+            "Properties": {
+                "Description": "Policy with base permissions for CodeBuild.",
+                "Path": "/",
+                "Roles": [
+                    {
+                        "Ref": "CodeBuildServiceRole"
+                    }
+                ],
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "logs:CreateLogGroup",
+                                "logs:PutLogEvents",
+                                "logs:CreateLogStream"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*"
+                                }
+                            ]
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:GetObject",
+                                "s3:GetObjectVersion",
+                                "s3:GetBucketAcl",
+                                "s3:GetBucketLocation"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::GetAtt": [
+                                        "KeyBucket",
+                                        "Arn"
+                                    ]
+                                },
+                                {
+                                    "Fn::Sub": "${KeyBucket.Arn}/*"
+                                }
+                            ]
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:PutObject"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::GetAtt": [
+                                        "OutputBucket",
+                                        "Arn"
+                                    ]
+                                },
+                                {
+                                    "Fn::Sub": "${OutputBucket.Arn}/*"
+                                }
+                            ]
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "kms:Encrypt",
+                                "kms:Decrypt",
+                                "kms:ReEncrypt*",
+                                "kms:GenerateDataKey*",
+                                "kms:DescribeKey"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::GetAtt": [
+                                        "KMSKey",
+                                        "Arn"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "CodeBuildEndpointPolicy": {
+            "Type": "AWS::IAM::ManagedPolicy",
+            "Properties": {
+                "Description": "Policy with permissions enabling CodeBuild to work with endpoints.",
+                "Path": "/",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "ec2:CreateNetworkInterface",
+                                "ec2:DescribeDhcpOptions",
+                                "ec2:DescribeNetworkInterfaces",
+                                "ec2:DeleteNetworkInterface",
+                                "ec2:DescribeSubnets",
+                                "ec2:DescribeSecurityGroups",
+                                "ec2:DescribeVpcs"
+                            ],
+                            "Resource": "*"
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "ec2:CreateNetworkInterfacePermission"
+                            ],
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "GitPullRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "git2cp-gitpull",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "kms:Decrypt"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "KMSKey",
+                                                "Arn"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:PutObject"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "OutputBucket"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "OutputBucket"
+                                                    },
+                                                    "/*"
+                                                ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetObject"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:s3:::",
+                                                    {
+                                                        "Ref": "KeyBucket"
+                                                    },
+                                                    "/enc_key"
+                                                ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        "arn:aws:logs:*:*:*"
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "codebuild:StartBuild",
+                                        "codebuild:BatchGetBuilds"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "GitPullCodeBuild",
+                                                "Arn"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "ec2:CreateNetworkInterface",
+                                        "ec2:DescribeDhcpOptions",
+                                        "ec2:DescribeNetworkInterfaces",
+                                        "ec2:DeleteNetworkInterface",
+                                        "ec2:DescribeSubnets",
+                                        "ec2:DescribeSecurityGroups",
+                                        "ec2:DescribeVpcs"
+                                    ],
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "ec2:CreateNetworkInterfacePermission"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "GitPullCodeBuild": {
+            "Type": "AWS::CodeBuild::Project",
+            "Properties": {
+                "VpcConfig": {
+                    "Fn::If": [
+                        "ShouldRunInVPC",
+                        {
+                            "SecurityGroupIds": [
+                                {
+                                    "Ref": "GitPullSecurityGroup"
+                                }
+                            ],
+                            "Subnets": {
+                                "Ref": "SubnetIds"
+                            },
+                            "VpcId": {
+                                "Ref": "VPCId"
+                            }
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Artifacts": {
+                    "Type": "NO_ARTIFACTS"
+                },
+                "Environment": {
+                    "Image": "aws/codebuild/standard:2.0",
+                    "Type": "LINUX_CONTAINER",
+                    "ComputeType": "BUILD_GENERAL1_SMALL"
+                },
+                "QueuedTimeoutInMinutes": 60,
+                "ServiceRole": {
+                    "Fn::GetAtt": [
+                        "CodeBuildServiceRole",
+                        "Arn"
+                    ]
+                },
+                "Source": {
+                    "BuildSpec": "version: 0.2\nenv:\n  exported-variables:\n    - GIT_COMMIT_ID\n    - GIT_COMMIT_MSG\nphases:\n  install:\n      runtime-versions:\n          python: 3.7\n      # commands:\n      # - pip3 install boto3\n  build:\n      commands:\n      - echo \"=======================Start-Deployment=============================\"\n      - echo \"Getting the SSH Private Key\"\n      - |\n        python3 - << \"EOF\"\n        from boto3 import client\n        import os\n        s3 = client('s3')\n        kms = client('kms')\n        enckey = s3.get_object(Bucket=os.getenv('KeyBucket'), Key=os.getenv('KeyObject'))['Body'].read()\n        privkey = kms.decrypt(CiphertextBlob=enckey)['Plaintext']\n        with open('enc_key.pem', 'w') as f:\n            print(privkey.decode(\"utf-8\"), file=f)\n        EOF\n      - mv ./enc_key.pem ~/.ssh/id_rsa\n      - ls ~/.ssh/\n      - echo \"Setting SSH config profile\"\n      - | \n        cat > ~/.ssh/config <<EOF\n        Host *\n          AddKeysToAgent yes\n          StrictHostKeyChecking no\n          IdentityFile ~/.ssh/id_rsa\n        EOF\n      - chmod 600 ~/.ssh/id_rsa\n      - echo \"Cloning the repository $GitUrl on branch $Branch\"\n      - git clone --single-branch --depth=1 --branch $Branch $GitUrl .\n      - ls\n      - echo \"Zipping the checked out contents\"\n      - |\n        if [ \"$exclude_git\" = \"True\" ]; then\n          zip -r $outputbucketkey ./ -x '*.git*'\n        else \n          zip -r $outputbucketkey ./\n        fi\n      - ls -alh\n      - echo \"Put the zipped Object to Output Bucket\"\n      - aws s3 cp $outputbucketkey s3://$outputbucket/$outputbucketpath # --sse aws:kms --sse-kms-key-id $CodePipelineArtifactKMSKeyId\n      - export GIT_COMMIT_ID=$(git rev-parse --short HEAD)\n      - echo $GIT_COMMIT_ID\n      - export GIT_COMMIT_MSG=\"$(git log -1 --pretty=%B)\"\n      - echo $GIT_COMMIT_MSG\n      - echo \"=======================End-Deployment=============================\"\n",
+                    "Type": "NO_SOURCE"
+                },
+                "TimeoutInMinutes": 14
+            }
+        },
+        "GitPullLambda": {
+            "DependsOn": "CopyZips",
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Handler": "lambda_function.lambda_handler",
+                "MemorySize": 128,
+                "Role": {
+                    "Fn::GetAtt": [
+                        "GitPullRole",
+                        "Arn"
+                    ]
+                },
+                "Runtime": "python3.8",
+                "Timeout": 900,
+                "VpcConfig": {
+                    "Fn::If": [
+                        "ShouldRunInVPC",
+                        {
+                            "SecurityGroupIds": [
+                                {
+                                    "Ref": "GitPullSecurityGroup"
+                                }
+                            ],
+                            "SubnetIds": {
+                                "Ref": "SubnetIds"
+                            }
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Environment": {
+                    "Variables": {
+                        "ExcludeGit": {
+                            "Ref": "ExcludeGit"
+                        },
+                        "GitPullCodeBuild": {
+                            "Ref": "GitPullCodeBuild"
+                        }
+                    }
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Ref": "LambdaZipsBucket"
+                    },
+                    "S3Key": {
+                        "Fn::Sub": "${QSS3KeyPrefix}functions/packages/GitPullS3/lambda.zip"
+                    }
+                }
+            }
+        },
+        "GitPullSecurityGroup": {
+            "Condition": "ShouldRunInVPC",
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Security Group to allow the Lambda function to access the Git service.",
+                "SecurityGroupEgress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": 0,
+                        "IpProtocol": "tcp",
+                        "ToPort": 65535
+                    }
+                ],
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": {
+                            "Ref": "VPCCidrRange"
+                        },
+                        "FromPort": 0,
+                        "IpProtocol": "tcp",
+                        "ToPort": 65535
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPCId"
+                }
+            }
+        },
+        "WebHookRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "apigateway.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+                ],
+                "Policies": [
+                    {
+                        "PolicyName": "git2cp-webhook",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "lambda:InvokeAsync",
+                                        "lambda:InvokeFunction"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "GitPullLambda",
+                                                "Arn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "WebHookApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "swagger": "2.0",
+                    "info": {
+                        "version": "2016-07-26T07:34:38Z",
+                        "title": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    "G2CP-",
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    }
+                                ]
+                            ]
+                        }
+                    },
+                    "schemes": [
+                        "https"
+                    ],
+                    "paths": {
+                        "/gitpull": {
+                            "post": {
+                                "consumes": [
+                                    "application/json"
+                                ],
+                                "produces": [
+                                    "application/json"
+                                ],
+                                "responses": {
+                                    "200": {
+                                        "description": "200 response",
+                                        "schema": {
+                                            "$ref": "#/definitions/Empty"
+                                        }
+                                    }
+                                },
+                                "x-amazon-apigateway-integration": {
+                                    "type": "aws",
+                                    "credentials": {
+                                        "Fn::GetAtt": [
+                                            "WebHookRole",
+                                            "Arn"
+                                        ]
+                                    },
+                                    "responses": {
+                                        "default": {
+                                            "statusCode": "200"
+                                        }
+                                    },
+                                    "requestParameters": {
+                                        "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+                                    },
+                                    "passthroughBehavior": "when_no_templates",
+                                    "httpMethod": "POST",
+                                    "uri": {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:aws:apigateway:",
+                                                {
+                                                    "Ref": "AWS::Region"
+                                                },
+                                                ":lambda:path//2015-03-31/functions/",
+                                                {
+                                                    "Fn::GetAtt": [
+                                                        "GitPullLambda",
+                                                        "Arn"
+                                                    ]
+                                                },
+                                                "/invocations"
+                                            ]
+                                        ]
+                                    },
+                                    "requestTemplates": {
+                                        "application/json": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "#set($allParams = $input.params())\n",
+                                                    "{\n",
+                                                    "\"body-json\" : $input.json('$'),\n",
+                                                    "\"params\" : {\n",
+                                                    "#foreach($type in $allParams.keySet())\n",
+                                                    "    #set($params = $allParams.get($type))\n",
+                                                    "\"$type\" : {\n",
+                                                    "    #foreach($paramName in $params.keySet())\n",
+                                                    "    \"$paramName\" : \"$util.escapeJavaScript($params.get($paramName))\"\n",
+                                                    "        #if($foreach.hasNext),#end\n",
+                                                    "    #end\n",
+                                                    "}\n",
+                                                    "    #if($foreach.hasNext),#end\n",
+                                                    "#end\n",
+                                                    "},\n",
+                                                    "\"stage-variables\" : {\n",
+                                                    "#foreach($key in $stageVariables.keySet())\n",
+                                                    "\"$key\" : \"$util.escapeJavaScript($stageVariables.get($key))\"\n",
+                                                    "    #if($foreach.hasNext),#end\n",
+                                                    "#end\n",
+                                                    "},\n",
+                                                    "\"context\" : {\n",
+                                                    "    \"account-id\" : \"$context.identity.accountId\",\n",
+                                                    "    \"api-id\" : \"$context.apiId\",\n",
+                                                    "    \"api-key\" : \"$context.identity.apiKey\",\n",
+                                                    "    \"authorizer-principal-id\" : \"$context.authorizer.principalId\",\n",
+                                                    "    \"caller\" : \"$context.identity.caller\",\n",
+                                                    "    \"cognito-authentication-provider\" : \"$context.identity.cognitoAuthenticationProvider\",\n",
+                                                    "    \"cognito-authentication-type\" : \"$context.identity.cognitoAuthenticationType\",\n",
+                                                    "    \"cognito-identity-id\" : \"$context.identity.cognitoIdentityId\",\n",
+                                                    "    \"cognito-identity-pool-id\" : \"$context.identity.cognitoIdentityPoolId\",\n",
+                                                    "    \"http-method\" : \"$context.httpMethod\",\n",
+                                                    "    \"stage\" : \"$context.stage\",\n",
+                                                    "    \"source-ip\" : \"$context.identity.sourceIp\",\n",
+                                                    "    \"user\" : \"$context.identity.user\",\n",
+                                                    "    \"user-agent\" : \"$context.identity.userAgent\",\n",
+                                                    "    \"user-arn\" : \"$context.identity.userArn\",\n",
+                                                    "    \"request-id\" : \"$context.requestId\",\n",
+                                                    "    \"resource-id\" : \"$context.resourceId\",\n",
+                                                    "    \"resource-path\" : \"$context.resourcePath\",\n",
+                                                    "    \"allowed-ips\" : \"$stageVariables.allowedips\",\n",
+                                                    "    \"api-secrets\" : \"$stageVariables.apisecrets\",\n",
+                                                    "    \"key-bucket\" : \"",
+                                                    {
+                                                        "Ref": "KeyBucket"
+                                                    },
+                                                    "\",\n",
+                                                    "    \"output-bucket\" : \"$stageVariables.outputbucket\",\n",
+                                                    "    \"public-key\" : \"",
+                                                    {
+                                                        "Ref": "CreateSSHKey"
+                                                    },
+                                                    "\",\n",
+                                                    "    \"raw-body\" : \"$util.escapeJavaScript($input.body).replace(\"\\'\",\"'\")\"\n",
+                                                    "    }\n",
+                                                    "}"
+                                                ]
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "securityDefinitions": {
+                        "sigv4": {
+                            "type": "apiKey",
+                            "name": "Authorization",
+                            "in": "header",
+                            "x-amazon-apigateway-authtype": "awsSigv4"
+                        }
+                    },
+                    "definitions": {
+                        "Empty": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "WebHookApiDeployment": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "WebHookApi"
+                },
+                "StageName": "DummyStage"
+            }
+        },
+        "WebHookApiProdStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "WebHookApiDeployment"
+                },
+                "RestApiId": {
+                    "Ref": "WebHookApi"
+                },
+                "StageName": "Prod",
+                "Variables": {
+                    "outputbucket": {
+                        "Ref": "OutputBucket"
+                    },
+                    "allowedips": {
+                        "Fn::If": [
+                            "UseAllowedIps",
+                            {
+                                "Ref": "AllowedIps"
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    "apisecrets": {
+                        "Fn::If": [
+                            "UseApiSecret",
+                            {
+                                "Ref": "ApiSecret"
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "CustomDomainCertificate": {
+            "Condition": "UseCustomDomain",
+            "Type": "AWS::CertificateManager::Certificate",
+            "Properties": {
+                "DomainName": {
+                    "Ref": "CustomDomainName"
+                }
+            }
+        },
+        "WebHookApiCustomDomainName": {
+            "Condition": "UseCustomDomain",
+            "Type": "AWS::ApiGateway::DomainName",
+            "Properties": {
+                "CertificateArn": {
+                    "Ref": "CustomDomainCertificate"
+                },
+                "DomainName": {
+                    "Ref": "CustomDomainName"
+                }
+            }
+        },
+        "WebHookApiCustomDomainNameMapping": {
+            "Condition": "UseCustomDomain",
+            "Type": "AWS::ApiGateway::BasePathMapping",
+            "Properties": {
+                "DomainName": {
+                    "Ref": "CustomDomainName"
+                },
+                "RestApiId": {
+                    "Ref": "WebHookApi"
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "CustomDomainNameCNAME": {
+            "Value": {
+                "Fn::If": [
+                    "UseCustomDomain",
+                    {
+                        "Fn::GetAtt": [
+                            "WebHookApiCustomDomainName",
+                            "DistributionDomainName"
+                        ]
+                    },
+                    ""
+                ]
+            }
+        },
+        "PublicSSHKey": {
+            "Value": {
+                "Ref": "CreateSSHKey"
+            }
+        },
+        "GitPullWebHookApi": {
+            "Value": {
+                "Fn::Join": [
+                    "",
+                    [
+                        " https://",
+                        {
+                            "Fn::If": [
+                                "UseCustomDomain",
+                                {
+                                    "Ref": "CustomDomainName"
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            {
+                                                "Ref": "WebHookApi"
+                                            },
+                                            ".execute-api.",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            ".amazonaws.com"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        },
+                        "/",
+                        {
+                            "Ref": "WebHookApiProdStage"
+                        },
+                        "/gitpull"
+                    ]
+                ]
+            }
+        },
+        "OutputBucketName": {
+            "Value": {
+                "Ref": "OutputBucket"
+            }
+        }
+    }
+}

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -141,7 +141,7 @@ resource "aws_cloudformation_stack" "git2s3" {
   name          = var.git2s3_stack_name
   template_body = file("${path.module}/git2s3.template")
   parameters    = {
-    AllowedIps          = join(",",data.github_ip_ranges.ips.git)
+    AllowedIps          = regex("^[0-9.,\\/]+?\\/32",join(",",data.github_ip_ranges.ips.git))
     QSS3BucketName      = "aws-quickstart"
     OutputBucketName    = ""
     ScmHostnameOverride = ""

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -1,0 +1,169 @@
+# -- Variables --
+variable "bucket_name_prefix" {
+  description = "First substring in S3 bucket name of $bucket_name_prefix-public-artifacts-$region"
+  type        = string
+}
+
+variable "log_bucket" {
+  description = "Name of the bucket used for S3 logging."
+  type        = string
+  default     = "s3-access-logs"
+}
+
+variable "region" {
+  default     = "us-west-2"
+  description = "AWS Region"
+}
+
+variable "inventory_bucket_arn" {
+  description = "ARN of the S3 bucket used for collecting the S3 Inventory reports."
+  type        = string
+}
+
+variable "sse_algorithm" {
+  description = "SSE algorithm to use to encrypt reports in S3 Inventory bucket."
+  type        = string
+  default     = "aws:kms"
+}
+
+variable "git2s3_stack_name" {
+  description = "Name for the Git2S3 CloudFormation Stack"
+  type        = string
+}
+
+variable "external_account_ids" {
+  description = "List of additional AWS account IDs, if any, to be permitted access to the public-artifacts bucket"
+  type        = list(string)
+  default     = []
+}
+
+locals {
+  git2s3_output_bucket = chomp(aws_cloudformation_stack.git2s3.outputs["OutputBucketName"])
+  log_bucket           = "${var.bucket_name_prefix}.s3-access-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
+  inventory_bucket     = "${var.bucket_name_prefix}.s3-inventory.${data.aws_caller_identity.current.account_id}-${var.region}"
+}
+
+# -- Data Sources --
+data "github_ip_ranges" "ips" {
+}
+
+data "aws_iam_policy_document" "git2s3_output_bucket" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = formatlist("arn:aws:iam::%s:root", var.external_account_ids)
+    }
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
+    resources = [
+      "arn:aws:s3:::${local.git2s3_output_bucket}",
+      "arn:aws:s3:::${local.git2s3_output_bucket}/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "artifact_bucket" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = formatlist("arn:aws:iam::%s:root", var.external_account_ids)
+    }
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.artifact_bucket}",
+      "arn:aws:s3:::${var.artifact_bucket}/*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = formatlist("arn:aws:iam::%s:root", var.external_account_ids)
+    }
+    actions = [
+      "s3:Put*",
+      "s3:Delete*",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.artifact_bucket}/packer_config/*"
+    ]
+  }
+}
+
+# -- Resources --
+
+resource "aws_cloudformation_stack" "git2s3" {
+  name          = "CodeSync-IdentityBaseImage"
+  template_body = file("${path.module}/git2s3.template")
+  parameters    = {
+    AllowedIps          = data.github_ip_ranges.ips.git
+    QSS3BucketName      = "aws-quickstart"
+    OutputBucketName    = ""
+    ScmHostnameOverride = ""
+    ExcludeGit          = "True"
+    VPCId               = ""
+    CustomDomainName    = ""
+    QSS3BucketRegion    = "us-east-1"
+    ApiSecret           = ""
+    QSS3KeyPrefix       = "quickstart-git2s3/"
+    VPCCidrRange        = ""
+    SubnetIds           = ""
+  }
+  capabilities = ["CAPABILITY_IAM"]
+}
+
+resource "aws_s3_bucket" "artifact_bucket" {
+  bucket = "${var.bucket_name_prefix}-public-artifacts-${var.region}"
+  acl    = "private"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = aws_s3_bucket.s3-access-logs.id
+    target_prefix = "${local.state_bucket}/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+
+resource "aws_s3_bucket_policy" "git2s3_output_bucket" {
+  bucket = local.git2s3_output_bucket
+  policy = data.aws_iam_policy_document.git2s3_output_bucket.json
+}
+
+resource "aws_s3_bucket_policy" "artifact_bucket" {
+  bucket = var.artifact_bucket
+  policy = data.aws_iam_policy_document.artifact_bucket.json
+}
+
+resource "aws_s3_bucket_object" "git2s3_output_bucket_name" {
+  bucket       = var.artifact_bucket
+  key          = "git2s3/OutputBucketName"
+  content      = local.git2s3_output_bucket
+  content_type = "text/plain"
+}
+
+output "output_bucket" {
+  value = aws_s3_bucket_object.git2s3_output_bucket_name.key
+}

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -1,3 +1,14 @@
+# -- Providers --
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 2.9"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
 # -- Variables --
 variable "bucket_name_prefix" {
   description = "First substring in S3 bucket name of $bucket_name_prefix-public-artifacts-$region"
@@ -104,7 +115,7 @@ data "aws_iam_policy_document" "artifact_bucket" {
       "${aws_s3_bucket.artifact_bucket.arn}/*"
     ]
   }
-  
+
   statement {
     effect = "Allow"
     principals {
@@ -124,7 +135,7 @@ data "aws_iam_policy_document" "artifact_bucket" {
 # -- Resources --
 
 resource "aws_cloudformation_stack" "git2s3" {
-  name          = "CodeSync-IdentityBaseImage"
+  name          = var.git2s3_stack_name
   template_body = file("${path.module}/git2s3.template")
   parameters    = {
     AllowedIps          = data.github_ip_ranges.ips.git


### PR DESCRIPTION
## tl;dr

New Terraform module that adds the creation of a public-artifacts S3 bucket (with, if desired, multi/cross-account access), with a key pointing to the `OutputBucket` from the Git2S3 CloudFormation Stack. Full details in the README.md

Addresses https://github.com/18F/identity-devops/issues/3129