### PR TITLE
make IAM policy attachments depend on the group(s) existing first

### DIFF
--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -46,7 +46,10 @@ resource "aws_iam_policy_attachment" "group_policy" {
   groups     = each.value
   policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${each.key}"
 
-  depends_on = [var.policy_depends_on]
+  depends_on = [
+    var.policy_depends_on,
+    aws_iam_group.iam_group
+  ]
 }
 
 # -- Outputs --

--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "role_policy_doc" {
         "sts:AssumeRole"
       ]
       resources = [
-        for arn in each.value : "${arn}"
+        for arn in each.value : arn
       ]
       condition {
       test     = "StringEquals"


### PR DESCRIPTION
If an IAM group doesn't exist at the time Terraform tries to create its `aws_iam_policy_attachment.group_policy` resource(s), the deploy will fail:

```
Error: [WARN] Error updating user, role, or group list from IAM Policy Attachment SandboxAssumeTerraform:
– NoSuchEntity: The group with name socreadonly cannot be found.
```

This adds `aws_iam_group.iam_group` as a dependency for each `aws_iam_policy_attachment.group_policy` for that group -- i.e. all groups must exist first -- thus ensuring that the resources are created and in the right order.

(Also -- a minor syntax fix in `iam_masterassume`, where interpolation of `arn` does not require explicit declaration.)