### PR TITLE
Update lambda handlers

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "kms" {
       "kms:*",
     ]
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       ]
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "kms" {
       "kms:DescribeKey",
     ]
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = concat(
         var.ec2_kms_arns
       )
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "kms" {
       "*",
     ]
     principals {
-      type        = "Service"
+      type = "Service"
       identifiers = [
         "events.amazonaws.com",
         "sns.amazonaws.com",
@@ -642,7 +642,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
   function_name = local.ct_processor_lambda_name
   description   = "18F/identity-lambda-functions: KMS CT Log Processor"
   role          = aws_iam_role.cloudtrail_processor.arn
-  handler       = "main.Functions::IdentityKMSMonitor::CloudTrailToDynamoHandler.process"
+  handler       = "main.IdentityKMSMonitor::CloudTrailToDynamoHandler.process"
   runtime       = "ruby2.7"
   timeout       = 120 # seconds
 
@@ -665,7 +665,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 
 module "ct-processor-github-alerts" {
   source = "github.com/18F/identity-terraform//lambda_alerts?ref=897cd9f749ead05a97b0f904a5dedfe83d9a9566"
-  
+
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
   alarm_actions        = [var.alarm_sns_topic_arn]
@@ -831,7 +831,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
   function_name = local.cw_processor_lambda_name
   description   = "18F/identity-lambda-functions: KMS CW Log Processor"
   role          = aws_iam_role.cloudwatch_processor.arn
-  handler       = "main.Functions::IdentityKMSMonitor::CloudWatchKMSHandler.process"
+  handler       = "main.IdentityKMSMonitor::CloudWatchKMSHandler.process"
   runtime       = "ruby2.7"
   timeout       = 120 # seconds
 
@@ -853,7 +853,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 
 module "cw-processor-github-alerts" {
   source = "github.com/18F/identity-terraform//lambda_alerts?ref=897cd9f749ead05a97b0f904a5dedfe83d9a9566"
-  
+
   enabled              = 1
   function_name        = local.cw_processor_lambda_name
   alarm_actions        = [var.alarm_sns_topic_arn]
@@ -974,7 +974,7 @@ resource "aws_lambda_function" "event_processor" {
   function_name = local.event_processor_lambda_name
   description   = "18F/identity-lambda-functions: KMS Log Event Processor"
   role          = aws_iam_role.event_processor.arn
-  handler       = "main.Functions::IdentityKMSMonitor::CloudWatchEventGenerator.process"
+  handler       = "main.IdentityKMSMonitor::CloudWatchEventGenerator.process"
   runtime       = "ruby2.7"
   timeout       = 120 # seconds
 


### PR DESCRIPTION
https://gsa-tts.slack.com/archives/C16RSBG49/p1629919283040400

```
2.7.4 :083 > Functions::IdentityKMSMonitor
Traceback (most recent call last):
        4: from /Users/jjg/.rvm/rubies/ruby-2.7.4/bin/irb:23:in `<main>'
        3: from /Users/jjg/.rvm/rubies/ruby-2.7.4/bin/irb:23:in `load'
        2: from /Users/jjg/.rvm/rubies/ruby-2.7.4/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        1: from (irb):83
NameError (uninitialized constant Functions::IdentityKMSMonitor)
```

```
2.7.4 :084 > IdentityAudit::GithubAuditor
 => IdentityAudit::GithubAuditor 
```

```
 :083 > 
 :084 > IdentityKMSMonitor::CloudTrailToDynamoHandler
 => IdentityKMSMonitor::CloudTrailToDynamoHandler 
```


Testing in `pt`

```
  # module.kms_logging.aws_lambda_function.cloudwatch_processor will be updated in-place
  ~ resource "aws_lambda_function" "cloudwatch_processor" {
        arn                            = "arn:aws:lambda:us-west-2:894947205914:function:pt-cloudwatch-kms"
        description                    = "18F/identity-lambda-functions: KMS CW Log Processor"
        function_name                  = "pt-cloudwatch-kms"
      ~ handler                        = "main.Functions::IdentityKMSMonitor::CloudWatchKMSHandler.process" -> "main.IdentityKMSMonitor::CloudWatchKMSHandler.process"
        id                             = "pt-cloudwatch-kms"
        invoke_arn                     = "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:894947205914:function:pt-cloudwatch-kms/invocations"
        last_modified                  = "2021-08-25T22:29:20.682+0000"
        layers                         = []
        memory_size                    = 128
        package_type                   = "Zip"
        publish                        = false
        qualified_arn                  = "arn:aws:lambda:us-west-2:894947205914:function:pt-cloudwatch-kms:4"
        reserved_concurrent_executions = -1
        role                           = "arn:aws:iam::894947205914:role/pt-cloudwatch-kms-execution"
        runtime                        = "ruby2.7"
        s3_bucket                      = "login-gov.lambda-functions.894947205914-us-west-2"
        s3_key                         = "circleci/identity-lambda-functions/40a8d2e68705313599e972a1cf50fd5a897ecc45.zip"
        source_code_hash               = "yEvP7mqLKYKjyVQI6Qy09A1ofxPT+fkiGfRclp3XfVQ="
        source_code_size               = 4288776
        tags                           = {
            "environment" = "pt"
            "source_repo" = "https://github.com/18F/identity-lambda-functions"
        }
        tags_all                       = {
            "environment" = "pt"
            "source_repo" = "https://github.com/18F/identity-lambda-functions"
        }
        timeout                        = 120
        version                        = "4"

        environment {
            variables = {
                "DDB_TABLE"           = "pt-kms-logging"
                "DEBUG"               = ""
                "LOG_LEVEL"           = "0"
                "RETENTION_DAYS"      = "365"
                "SNS_EVENT_TOPIC_ARN" = "arn:aws:sns:us-west-2:894947205914:pt-kms-logging-events"
            }
        }

        tracing_config {
            mode = "PassThrough"
        }
    }

  # module.kms_logging.aws_lambda_function.event_processor will be updated in-place
  ~ resource "aws_lambda_function" "event_processor" {
        arn                            = "arn:aws:lambda:us-west-2:894947205914:function:pt-kmslog-event-processor"
        description                    = "18F/identity-lambda-functions: KMS Log Event Processor"
        function_name                  = "pt-kmslog-event-processor"
      ~ handler                        = "main.Functions::IdentityKMSMonitor::CloudWatchEventGenerator.process" -> "main.IdentityKMSMonitor::CloudWatchEventGenerator.process"
        id                             = "pt-kmslog-event-processor"
        invoke_arn                     = "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:894947205914:function:pt-kmslog-event-processor/invocations"
        last_modified                  = "2021-08-25T22:29:10.892+0000"
        layers                         = []
        memory_size                    = 128
        package_type                   = "Zip"
        publish                        = false
        qualified_arn                  = "arn:aws:lambda:us-west-2:894947205914:function:pt-kmslog-event-processor:3"
        reserved_concurrent_executions = -1
        role                           = "arn:aws:iam::894947205914:role/pt-kmslog-event-processor-execution"
        runtime                        = "ruby2.7"
        s3_bucket                      = "login-gov.lambda-functions.894947205914-us-west-2"
        s3_key                         = "circleci/identity-lambda-functions/40a8d2e68705313599e972a1cf50fd5a897ecc45.zip"
        source_code_hash               = "yEvP7mqLKYKjyVQI6Qy09A1ofxPT+fkiGfRclp3XfVQ="
        source_code_size               = 4288776
        tags                           = {
            "environment" = "pt"
            "source_repo" = "https://github.com/18F/identity-lambda-functions"
        }
        tags_all                       = {
            "environment" = "pt"
            "source_repo" = "https://github.com/18F/identity-lambda-functions"
        }
        timeout                        = 120
        version                        = "3"

        environment {
            variables = {
                "DEBUG"     = ""
                "ENV_NAME"  = "pt"
                "LOG_LEVEL" = "0"
            }
        }

        tracing_config {
            mode = "PassThrough"
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.

```

and we're back

<img width="2217" alt="Screen Shot 2021-08-25 at 4 03 40 PM" src="https://user-images.githubusercontent.com/24955/130875606-252dfc9a-a623-4b2f-be4d-f725cbcbe586.png">
