### PR TITLE
use actual files instead of symlinks

### DIFF
--- a/acm_certificate/versions.tf
+++ b/acm_certificate/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/asg_lifecycle_notifications/versions.tf
+++ b/asg_lifecycle_notifications/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/asg_recycle/versions.tf
+++ b/asg_recycle/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/cloudwatch_dashboard_alb/versions.tf
+++ b/cloudwatch_dashboard_alb/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/cloudwatch_dashboard_rds/versions.tf
+++ b/cloudwatch_dashboard_rds/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/config_fedramp_conformance/versions.tf
+++ b/config_fedramp_conformance/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -132,7 +132,7 @@ lifecycle_rule {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=53ab4c954af5139a7988d475b6f19fb959caa63e"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/elb_access_logs_bucket/versions.tf
+++ b/elb_access_logs_bucket/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/elb_http_alerts/versions.tf
+++ b/elb_http_alerts/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -110,7 +110,7 @@ resource "aws_s3_bucket" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=53ab4c954af5139a7988d475b6f19fb959caa63e"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/git2s3_artifacts/versions.tf
+++ b/git2s3_artifacts/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/iam_assumegroup/versions.tf
+++ b/iam_assumegroup/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/iam_assumerole/versions.tf
+++ b/iam_assumerole/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/iam_masterassume/versions.tf
+++ b/iam_masterassume/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/iam_masterusers/versions.tf
+++ b/iam_masterusers/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/kms_keymaker/versions.tf
+++ b/kms_keymaker/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -614,7 +614,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=53ab4c954af5139a7988d475b6f19fb959caa63e"
   
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -802,7 +802,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=53ab4c954af5139a7988d475b6f19fb959caa63e"
   
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/kms_log/versions.tf
+++ b/kms_log/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/lambda_alerts/versions.tf
+++ b/lambda_alerts/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/lambda_pipeline/versions.tf
+++ b/lambda_pipeline/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/launch_template/versions.tf
+++ b/launch_template/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/s3_batch_inventory/versions.tf
+++ b/s3_batch_inventory/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -88,7 +88,7 @@ resource "aws_s3_bucket" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=53ab4c954af5139a7988d475b6f19fb959caa63e"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/s3_bucket_block/versions.tf
+++ b/s3_bucket_block/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/s3_config/versions.tf
+++ b/s3_config/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/ses_dkim_r53/versions.tf
+++ b/ses_dkim_r53/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/slack_lambda/versions.tf
+++ b/slack_lambda/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/squid_cloudwatch_filters/versions.tf
+++ b/squid_cloudwatch_filters/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/ssm/versions.tf
+++ b/ssm/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -237,7 +237,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=53ab4c954af5139a7988d475b6f19fb959caa63e"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/state_bucket/versions.tf
+++ b/state_bucket/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}

--- a/vpc_flow_cloudwatch_filters/versions.tf
+++ b/vpc_flow_cloudwatch_filters/versions.tf
@@ -1,1 +1,26 @@
-../versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+    }
+    external = {
+      source  = "hashicorp/external"
+    }
+    null = {
+      source  = "hashicorp/null"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+    github = {
+      source  = "integrations/github"
+    }
+    newrelic = {
+      source  = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 0.13.7"
+}


### PR DESCRIPTION
This seems to be what `auto-tf` is getting broken on, since it's throwing a lot of this:

```
╷
│ Error: Argument or block definition required
│ 
│ On ../module/versions.tf line 1: An argument or block definition is
│ required here.
╵
```

This, oddly, DOES work when `apply`/`plan`ing locally -- something to dig into further later.