### PR TITLE
removing Terraform 0.13.7 references everywhere

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -132,7 +132,7 @@ lifecycle_rule {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -110,7 +110,7 @@ resource "aws_s3_bucket" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -614,7 +614,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
   
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -802,7 +802,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
   
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -88,7 +88,7 @@ resource "aws_s3_bucket" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -237,7 +237,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source = "github.com/18F/identity-terraform//s3_config?ref=59d78d2087cfb9554a7454ca455a9d7e221606a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/versions.tf
+++ b/versions.tf
@@ -22,5 +22,5 @@ terraform {
       source  = "newrelic/newrelic"
     }
   }
-  required_version = ">= 0.13.7"
+  required_version = ">= 1.0.2"
 }


### PR DESCRIPTION
Now that Terraform 1.0.2 is the standard everywhere, this removes support for 0.13.7 and other previous versions in the `login.gov` infrastructure. Second commit also updates the self-referencing SHAs (i.e. those using `s3_config`) within this repo.

Addresses https://github.com/18F/identity-devops/issues/3111