### PR TITLE
creation of 'dnssec' module for configuring/enabling DNSSEC signing for a domain/hosted zone

### DIFF
--- a/dnssec/README.md
+++ b/dnssec/README.md
@@ -1,0 +1,167 @@
+# `dnssec`
+
+<!-- MarkdownTOC -->
+
+- [Overview](#overview)
+- [Enabling DNSSEC Signing with a KSK](#enabling-dnssec-signing-with-a-ksk)
+- [KSK Key Rotation](#ksk-key-rotation)
+- [Resource Protection Using the `DNSSecDisablePrevent` Policy](#resource-protection-using-the-dnssecdisableprevent-policy)
+  - [Why Use Such A Restrictive Policy?](#why-use-such-a-restrictive-policy)
+  - [What About Lifecycle Rules?](#what-about-lifecycle-rules)
+- [Example Implementation](#example-implementation)
+- [Variables](#variables)
+  - [CloudWatch Alarm Description Fill-Ins](#cloudwatch-alarm-description-fill-ins)
+  - [Other Variables](#other-variables)
+
+<!-- /MarkdownTOC -->
+
+## Overview
+
+This module is used to create and enable DNSSEC configuration for a given domain (i.e. a hosted zone in Route 53). It creates:
+
+- a KMS key + alias, used as a key-signing key (KSK) for DNSSEC -- currently (as of 2021-12-14) created _only_ in the `us-east-1` region
+- an 'enable DNSSEC signing' resource, the actual AWS resource that sits on a hosted zone and allows DNSSEC signing to be configured / a DS record to be obtained
+- an (optional) IAM policy which _prevents_ premature deletion/disabling/etc. of the KSK/KMS key(s), the DNSSEC-enabled resource, or the hosted zone itself
+- CloudWatch Alarms to notify about DNSSEC errors, expiring KSKs, and other KSK-related alerts
+
+More info about how DNSSEC management and KSKs work in AWS can be found in the [Configuring DNSSEC Signing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec.html) section of AWS' Route 53 Developer Guide.
+
+## Enabling DNSSEC Signing with a KSK
+
+1. `apply` this module to enable DNSSEC signing for a hosted zone, and create a KMS-key-backed-KSK for said DNSSEC signing. You'll get the necessary values to create a DS record in the parent hosted zone from the Outputs, e.g. (using fake digest values here):
+  ```bash
+  primary_zone_active_ds_value = "12345 13 2 0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF"
+  primary_zone_dnssec_ksks = tomap({
+    "20211006" = tomap({
+      "digest_algorithm" = "SHA-256"
+      "digest_value" = "0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF"
+      "ds_record" = "12345 13 2 0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF"
+      "signing_algorithm" = "ECDSAP256SHA256"
+    })
+  })
+  ```
+2. With the `ds_record` info above, [establish a chain of trust](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-enable-signing.html#dns-configuring-dnssec-chain-of-trust) with your parent hosted zone in order to create a DS record. You may need to supply the `digest_algorithm`, `signing_algorithm`, and `digest_value` values separately, depending upon your registrar. 
+3. Once the updates have propagated (based upon the TTL for your domain record), you can verify that DNSSEC signing has been enabled, and is configured correctly in a few different ways:
+  - Use [DNSViz](https://dnsviz.net/) to verify the trust chain and see a visual representation of it, from the parent hosted zone to individual records (such as `AAAA`, `MX`, etc.) within your hosted zone
+  - `dig a DOMAINNAMEHERE +dnssec @9.9.9.10` - check if DNSSEC is validating using a non-validating cache (`ad` should be in the `flags` section)
+  - `dig DNSKEY DOMAINNAMEHERE +short` - look up the current KSK and ZSKs (KSK have a code of 257 and ZSK have a code of 256)
+
+## KSK Key Rotation
+
+1. The `dnssec_ksks` variable is a string map used to configure the KSKs for any given hosted zone, and for allow for easier rotation of said keys when required ([a best practice with regard to cryptographic keys in general, as well.](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-ksk.html#dns-configuring-dnssec-ksk-delete-ksk)):
+  ```hcl
+    dnssec_ksks = {
+      # 20211005" = "old",
+      "20211006" = "active"
+    }
+  ```
+  It defaults to having _one_ value, as Route 53 / AWS will complain if you attempt to build 2 at the same time:
+  ```bash
+  Error: error creating Route 53 Key Signing Key: ConcurrentModification: Database is currently busy. Please retry.
+  ```
+2. To add a new key, uncomment the `"old"` line in the `var.dnssec_ksks` map, changing the date (i.e. `"2111005"`) to the date you are creating this new key (to help keep track of the lifetime of your keys). e.g.:
+  ```hcl
+    dnssec_ksks = {
+      "20221005" = "active",
+      "20211006" = "active"
+    }
+  ```
+3. `apply`-ing this will generate another block in the `primary_zone_dnssec_ksks` output with the values for a new DS record. With this information in hand, you can follow the process above to _update_ the DS record (created with your parent hosted zone) to contain the digest/algorithm values of the new key.
+4. Once the DS record and DNSSEC signing have been updated with the values from the new key -- and the changes have propagated -- you can comment out the now-unused key, change its value to `"old"` and the new one to `"active"`, and then `apply` the changes to deactivate and delete the old key, e.g.:
+  ```hcl
+    dnssec_ksks = {
+      "20221005" = "active",
+      # "20211006" = "old"
+    }
+  ```
+
+## Resource Protection Using the `DNSSecDisablePrevent` Policy
+
+If the boolean variable `protect_resources` is set to **true** (also its default value), this module will create an IAM policy, `DNSSecDisablePrevent`, which adds an explicit **Deny** against any actions that could delete/disable the resources involved in this module, i.e.:
+
+- deactivation/deletion of KSK(s) / the respective KMS key(s)
+- disabling DNSSEC signing
+- deleting the Hosted Zone itself
+
+This IAM policy can then be attached to roles/users/groups as desired -- as an example, it could be one of the `custom_policy_arns` used when [creating roles via the `iam_assumerole` module (also in this repo!)](https://github.com/18F/identity-terraform/tree/main/iam_assumerole)
+
+### Why Use Such A Restrictive Policy?
+
+The possibility of accidental destruction of the 'DNSSEC-signing-enabled' resource, the KSK(s)/KMS key(s), and/or the Hosted Zone itself, is much higher when using Terraform or another third-party (i.e. non-AWS) tool to manage infrastructure (as critical warnings about such actions appear through AWS services, such as the console, but not in response to API calls made by Terraform). *This precise destruction -- via Terraform, in fact! -- [caused a minor, but long lasting, Slack outage in September 2021](https://slack.engineering/what-happened-during-slacks-dnssec-rollout/), even after extensive DNSSEC testing/prep on their part.*
+
+### What About Lifecycle Rules?
+
+For this module, the `lifecycle { prevent_destroy = true }` safeguard *is* attached to the DNSSEC-signing resource itself, but **not** to the KSK/KMS resources. Doing so would add significant complexity, and manual work, to the key rotation process, as explained below:
+
+Key rotation requires the ability to destroy the old, deactivated keys once they are fully confirmed to no longer be in use, and [lifecycle rules currently (as of 2021-12-14) do not support interpolation.](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#literal-values-only) Thus, logic cannot be written to change a lifecycle rule automatically when marking a key as inactive / commenting out a key in the `dnssec_ksks` string map. One would need to manually override/comment out the `lifecycle` block (in a local copy of `main.tf`), or remove it from the actual Terraform statefile (via `state pull` / `state push` commands), and run an *extra* `terraform apply` command, in order to remove the resources and keep Terraform's state accurate.
+
+Until such time that they *can* be configured with interpolation, the `lifecycle` blocks for the KSK/KMS resources are commented out, with the hope to include them as an additional safeguard in the future. Terraform *has* indicated an intent to implement this feature request in the near future, and further discussion and planning can be found within the `hashicorp/terraform` repo:
+- https://github.com/hashicorp/terraform/issues/3116
+- https://github.com/hashicorp/terraform/issues/4149
+
+## Example Implementation
+
+In `module/main.tf`:
+
+```hcl
+locals {
+  dnssec_runbook_prefix = ": https://identityexampledomain.com/wiki/Runbook:DNS#dnssec"
+}
+
+module "dnssec" {
+  source = "github.com/18F/identity-terraform//dnssec?ref=main"
+  #source = "../../../../identity-terraform/dnssec"
+
+  dnssec_ksks_action_req_alarm_desc = "${local.dnssec_runbook_prefix}_ksks_action_req"
+  dnssec_ksk_age_alarm_desc         = "${local.dnssec_runbook_prefix}_ksk_age"
+  dnssec_errors_alarm_desc          = "${local.dnssec_runbook_prefix}_errors"
+  dnssec_zone_name                  = var.root_domain
+  dnssec_zone_id                    = module.common_dns.primary_zone_id
+  alarm_actions                     = [module.sns_slack.sns_topic_arn]
+  dnssec_ksks                       = var.dnssec_ksks
+  protect_resources                 = true
+}
+```
+
+In an environment-specific `main.tf`:
+
+```hcl
+module "main" {
+  source = "../module"
+
+  root_domain = identityexampledomain.gov
+  dnssec_ksks = {
+      # 20211005" = "old",
+      "20211006" = "active"
+  }
+```
+
+## Variables
+
+### CloudWatch Alarm Description Fill-Ins
+
+As DNSSEC and proper key rotation can often be complex processes to follow -- often with a significant timespan between rotations -- we recommend using this `README` file, and/or other DNSSEC literature, as a guide for creating runbooks/documentation/etc. for team members who may be responsible for these resources. To help increase visibility of said documentation, the following variables are available to add additional content to the description of each corresponding CloudWatch Alarm:
+
+- `dnssec_ksks_action_req_alarm_desc`
+- `dnssec_ksk_age_alarm_desc`
+- `dnssec_errors_alarm_desc`
+
+The implementation above uses a `local` variable, `dnssec_runbook_prefix`, to add links to the description of each alarm; These links point to different sections of the runbook that describe the alarms. As an example:
+
+- With `dnssec_errors_alarm_desc` unset:
+  ```
+  alarm_description = "DNSSEC encountered 1+ errors in <24h"
+  ```
+- With `dnssec_errors_alarm_desc` set with the above example value/`local`:
+  ```
+  alarm_description = "DNSSEC encountered 1+ errors in <24h: https://identityexampledomain.com/wiki/Runbook:DNS#dnssec_errors"
+  ```
+
+### Other Variables
+
+`alarm_actions` - A list of ARNs to notify via the CloudWatch Alarms, i.e. SNS topics.
+`dnssec_ksk_max_days` - Maximum allowed age of a DNSSEC KSK before triggering a CloudWatch alarm.
+`dnssec_ksks` - Map of Key Signing Keys (KSKs) to provision for each hosted zone.
+`dnssec_zone_name` - Name of the Route53 DNS domain where DNSSEC signing will be enabled.
+`dnssec_zone_id` - ID of the Route53 DNS domain where DNSSEC signing will be enabled.
+`protect_resources` - Whether or not to create the IAM policy that prevents disabling/destruction of DNSSEC itself, the associated KSKs/KMS keys/aliases, and the Route53 Hosted Zone.

--- a/dnssec/README.md
+++ b/dnssec/README.md
@@ -91,11 +91,11 @@ The possibility of accidental destruction of the 'DNSSEC-signing-enabled' resour
 
 ### What About Lifecycle Rules?
 
-For this module, the `lifecycle { prevent_destroy = true }` safeguard *is* attached to the DNSSEC-signing resource itself, but **not** to the KSK/KMS resources. Doing so would add significant complexity, and manual work, to the key rotation process, as explained below:
+For this module, the `lifecycle { prevent_destroy = true }` safeguard is **not** attached to the various DNSSEC resources. Doing so would add significant complexity, and manual work, to the key rotation process, as explained below:
 
 Key rotation requires the ability to destroy the old, deactivated keys once they are fully confirmed to no longer be in use, and [lifecycle rules currently (as of 2021-12-14) do not support interpolation.](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#literal-values-only) Thus, logic cannot be written to change a lifecycle rule automatically when marking a key as inactive / commenting out a key in the `dnssec_ksks` string map. One would need to manually override/comment out the `lifecycle` block (in a local copy of `main.tf`), or remove it from the actual Terraform statefile (via `state pull` / `state push` commands), and run an *extra* `terraform apply` command, in order to remove the resources and keep Terraform's state accurate.
 
-Until such time that they *can* be configured with interpolation, the `lifecycle` blocks for the KSK/KMS resources are commented out, with the hope to include them as an additional safeguard in the future. Terraform *has* indicated an intent to implement this feature request in the near future, and further discussion and planning can be found within the `hashicorp/terraform` repo:
+Until such time that they *can* be configured with interpolation, the `lifecycle` blocks for these resources are commented out, with the hope to include them as an additional safeguard in the future. Terraform *has* indicated an intent to implement this feature request in the near future, and further discussion and planning can be found within the `hashicorp/terraform` repo:
 - https://github.com/hashicorp/terraform/issues/3116
 - https://github.com/hashicorp/terraform/issues/4149
 

--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -149,12 +149,9 @@ resource "aws_route53_hosted_zone_dnssec" "dnssec" {
   ]
   hosted_zone_id = var.dnssec_zone_id
 
-  # This block CAN remain, because preventing DNSSEC signing from
-  # deletion is paramount, and key rotation doesn't require this
-  # resource to be changed/interpolated through.
-  lifecycle {
-    prevent_destroy = true
-  }
+  #lifecycle {
+  #  prevent_destroy = true
+  #}
 }
 
 data "aws_iam_policy_document" "dnssec_disable_prevent" {

--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -1,0 +1,151 @@
+# https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-troubleshoot.html
+
+# -- Data Sources --
+
+data "aws_caller_identity" "current" {
+}
+
+data "aws_iam_policy_document" "ksk_policy" {
+  statement {
+    sid    = "Allow Route 53 DNSSEC Service Access To KMS Keys"
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetPublicKey",
+      "kms:Sign",
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "dnssec-route53.amazonaws.com"
+      ]
+    }
+    resources = [
+      "*"
+    ]
+  }
+  statement {
+    sid    = "Allow Route 53 DNSSEC Service To CreateGrant"
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant"
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "dnssec-route53.amazonaws.com"
+      ]
+    }
+    resources = [
+      "*"
+    ]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values = [
+        "true",
+      ]
+    }
+  }
+  statement {
+    sid    = "KMS IAM User Permissions"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+    resources = [
+      "*"
+    ]
+  }
+}
+
+# -- Providers
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.usw2,
+        aws.use1
+      ]
+    }
+  }
+}
+
+resource "aws_kms_key" "dnssec" {
+  for_each = var.dnssec_ksks
+  provider = aws.use1
+
+  customer_master_key_spec = "ECC_NIST_P256"
+  deletion_window_in_days  = 7
+  key_usage                = "SIGN_VERIFY"
+  policy                   = data.aws_iam_policy_document.ksk_policy.json
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_kms_alias" "dnssec" {
+  for_each = var.dnssec_ksks
+  provider = aws.use1
+
+  name          = "alias/${replace(var.dnssec_zone_name, "/\\./", "_")}-ksk-${each.key}"
+  target_key_id = aws_kms_key.dnssec[each.key].key_id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_route53_key_signing_key" "dnssec" {
+  for_each = var.dnssec_ksks
+
+  hosted_zone_id             = var.dnssec_zone_id
+  key_management_service_arn = aws_kms_key.dnssec[each.key].arn
+  name                       = "${var.dnssec_zone_name}-ksk-${each.key}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_route53_hosted_zone_dnssec" "dnssec" {
+  depends_on = [
+    aws_route53_key_signing_key.dnssec
+  ]
+  hosted_zone_id = var.dnssec_zone_id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "dnssec" {
+  for_each = var.dnssec_alarms
+
+  alarm_name        = "${var.dnssec_zone_name}-${each.key}"
+  alarm_description = lookup(each.value, "desc", "${var.dnssec_zone_name}-${each.key} alarm")
+  namespace         = "AWS/Route53"
+  metric_name       = join("",["DNSSEC",lookup(each.value, "metric_name", replace(each.key, "/[^a-zA-Z0-9 ]/", ""))])
+
+  dimensions = {
+    HostedZoneId = var.dnssec_zone_id
+  }
+
+  statistic           = lookup(each.value, "statistic", "Sum")
+  comparison_operator = lookup(each.value, "comp_operator", "GreaterThanThreshold")
+  threshold           = lookup(each.value, "statistic", 0)
+  period              = lookup(each.value, "period", 86400)
+  evaluation_periods  = lookup(each.value, "eval_periods", 1)
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.alarm_actions
+}
+

--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -71,7 +71,7 @@ locals {
   dnssec_alarms = {
     "dnssec_ksks_action_req" = {
       metric_name = "KSKActionRequired"
-      desc = join("",[
+      desc = join("", [
         "1+ DNSSEC KSKs require attention in <24h",
         var.dnssec_ksks_action_req_alarm_desc
       ])
@@ -80,14 +80,14 @@ locals {
       statistic   = "Maximum"
       threshold   = var.dnssec_ksk_max_days * 24 * 60 * 60
       metric_name = "KSKAge"
-      desc = join("",[
+      desc = join("", [
         "1+ DNSSEC KSKs are >${var.dnssec_ksk_max_days} days old",
         var.dnssec_ksk_age_alarm_desc
       ])
     }
     "dnssec_errors" = {
       metric_name = "Errors"
-      desc = join("",[
+      desc = join("", [
         "DNSSEC encountered 1+ errors in <24h",
         var.dnssec_errors_alarm_desc
       ])

--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -65,20 +65,6 @@ data "aws_iam_policy_document" "ksk_policy" {
   }
 }
 
-# -- Providers
-
-terraform {
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-      configuration_aliases = [
-        aws.usw2,
-        aws.use1
-      ]
-    }
-  }
-}
-
 # -- Locals
 
 locals {

--- a/dnssec/outputs.tf
+++ b/dnssec/outputs.tf
@@ -1,0 +1,21 @@
+output "root_zone_dnssec_ksks" {
+  description = "DNSSEC Key Signing Key information"
+
+  value = tomap({
+    for k, v in aws_route53_key_signing_key.dnssec : k => tomap({
+      digest_algorithm  = v.digest_algorithm_mnemonic,
+      digest_value      = v.digest_value,
+      signing_algorithm = v.signing_algorithm_mnemonic,
+      ds_record         = v.ds_record
+    })
+  })
+}
+
+output "active_ds_value" {
+  description = "DS value for the KSK marked as active"
+
+  # This mess pulls DS for the key with a value of "active".
+  # If no keys in var.dnssec_ksks have a value of "active" it will fail
+  value = aws_route53_key_signing_key.dnssec[[for k, v in var.dnssec_ksks : k if v == "active"][0]].ds_record
+}
+

--- a/dnssec/variables.tf
+++ b/dnssec/variables.tf
@@ -1,0 +1,46 @@
+variable "dnssec_alarms" {
+  description = "Data for any desired DNSSEC / KSK alarms in CloudWatch (if creating)"
+  type        = any
+  default     = {
+    "dnssec_alarm_example" = {
+      desc          = "ZONEID DNSSEC Alarm"
+      metric_name   = "MetricName"
+      statistic     = "Sum"
+      comp_operator = "GreaterThanThreshold"
+      statistic     = 0
+      period        = 86400
+      eval_periods  = 1
+    }
+  }
+}
+
+variable "alarm_actions" {
+  type        = list(string)
+  description = "A list of ARNs to notify when the alarms fire"
+}
+
+variable "dnssec_ksk_max_days" {
+  description = "Maxium age of DNSSEC KSK before alerting due to being too old"
+  type        = number
+  default     = 366
+}
+
+variable "dnssec_ksks" {
+  description = "Map of Key Signing Keys (KSKs) to provision for each zone"
+  # See key rotation notes in the README for more info here
+  type = map(string)
+  default = {
+    # "2111005" = "old",
+    "20211006" = "active"
+  }
+}
+
+variable "dnssec_zone_name" {
+  description = "Name of the Route53 DNS domain to to apply DNSSEC configuration to."
+  type        = string
+}
+
+variable "dnssec_zone_id" {
+  description = "ID of the Route53 DNS domain to to apply DNSSEC configuration to."
+  type        = string
+}

--- a/dnssec/variables.tf
+++ b/dnssec/variables.tf
@@ -1,17 +1,17 @@
 variable "alarm_actions" {
   type        = list(string)
-  description = "A list of ARNs to notify when the alarms fire"
+  description = "A list of ARNs to notify via the CloudWatch Alarms, i.e. SNS topics."
 }
 
 variable "dnssec_ksk_max_days" {
-  description = "Maxium age of DNSSEC KSK before alerting due to being too old"
+  description = "Maximum allowed age of a DNSSEC KSK before triggering a CloudWatch alarm."
   type        = number
   default     = 366
 }
 
 variable "dnssec_ksks" {
-  description = "Map of Key Signing Keys (KSKs) to provision for each zone"
-  # See key rotation notes in the README for more info here
+  description = "Map of Key Signing Keys (KSKs) to provision for each hosted zone."
+  # See the notes in the README for more information regarding the key rotation process!
   type = map(string)
   default = {
     # "2111005" = "old",
@@ -20,12 +20,12 @@ variable "dnssec_ksks" {
 }
 
 variable "dnssec_zone_name" {
-  description = "Name of the Route53 DNS domain to to apply DNSSEC configuration to."
+  description = "Name of the Route53 DNS domain where DNSSEC signing will be enabled."
   type        = string
 }
 
 variable "dnssec_zone_id" {
-  description = "ID of the Route53 DNS domain to to apply DNSSEC configuration to."
+  description = "ID of the Route53 DNS domain where DNSSEC signing will be enabled."
   type        = string
 }
 
@@ -59,5 +59,5 @@ variable "protect_resources" {
 Whether or not to create the IAM policy that prevents disabling/destruction of
 DNSSEC itself, the associated KSKs/KMS keys/aliases, and the Route53 Hosted Zone.
 EOM
-  default = true
+  default     = true
 }

--- a/dnssec/variables.tf
+++ b/dnssec/variables.tf
@@ -52,3 +52,12 @@ variable "dnssec_errors_alarm_desc" {
 i.e. link to internal documentation, help pages, etc.
 EOM
 }
+
+variable "protect_resources" {
+  type        = bool
+  description = <<EOM
+Whether or not to create the IAM policy that prevents disabling/destruction of
+DNSSEC itself, the associated KSKs/KMS keys/aliases, and the Route53 Hosted Zone.
+EOM
+  default = true
+}

--- a/dnssec/variables.tf
+++ b/dnssec/variables.tf
@@ -1,19 +1,3 @@
-variable "dnssec_alarms" {
-  description = "Data for any desired DNSSEC / KSK alarms in CloudWatch (if creating)"
-  type        = any
-  default     = {
-    "dnssec_alarm_example" = {
-      desc          = "ZONEID DNSSEC Alarm"
-      metric_name   = "MetricName"
-      statistic     = "Sum"
-      comp_operator = "GreaterThanThreshold"
-      statistic     = 0
-      period        = 86400
-      eval_periods  = 1
-    }
-  }
-}
-
 variable "alarm_actions" {
   type        = list(string)
   description = "A list of ARNs to notify when the alarms fire"
@@ -43,4 +27,28 @@ variable "dnssec_zone_name" {
 variable "dnssec_zone_id" {
   description = "ID of the Route53 DNS domain to to apply DNSSEC configuration to."
   type        = string
+}
+
+variable "dnssec_ksks_action_req_alarm_desc" {
+  type        = string
+  description = <<EOM
+(Optional) Extra text for the  dnssec_ksks_action_req CloudWatch Alarm description,
+i.e. link to internal documentation, help pages, etc.
+EOM
+}
+
+variable "dnssec_ksk_age_alarm_desc" {
+  type        = string
+  description = <<EOM
+(Optional) Extra text for the  dnssec_ksk_age CloudWatch Alarm description,
+i.e. link to internal documentation, help pages, etc.
+EOM
+}
+
+variable "dnssec_errors_alarm_desc" {
+  type        = string
+  description = <<EOM
+(Optional) Extra text for the  dnssec_errors CloudWatch Alarm description,
+i.e. link to internal documentation, help pages, etc.
+EOM
 }

--- a/dnssec/versions.tf
+++ b/dnssec/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -25,7 +25,7 @@ resource "aws_iam_user" "master_user" {
 }
 
 resource "aws_iam_group_membership" "master_group" {
-  for_each = transpose({for k, v in var.user_map : k => v.aws_groups})
+  for_each = transpose({ for k, v in var.user_map : k => v.aws_groups })
 
   name  = "${each.key}-group"
   group = each.key

--- a/versions.tf
+++ b/versions.tf
@@ -24,3 +24,17 @@ terraform {
   }
   required_version = ">= 1.0.2"
 }
+
+provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
+  alias  = "use1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "usw2"
+  region = var.region
+}

--- a/versions.tf
+++ b/versions.tf
@@ -26,15 +26,11 @@ terraform {
 }
 
 provider "aws" {
-  region = var.region
-}
-
-provider "aws" {
   alias  = "use1"
   region = "us-east-1"
 }
 
 provider "aws" {
   alias  = "usw2"
-  region = var.region
+  region = "us-west-2"
 }


### PR DESCRIPTION
This module has been moved into this repo as part of Login.gov's continuing effort to provide Terraform modules that we use to the open-source community.

Detailed information, including available variables, implementation examples, and recommended steps for effective key-signing key (KSK) rotation, is available in the `README` file within the module directory.