### PR TITLE
Use min/max statistics in RDS dashboard

### DIFF
--- a/cloudwatch_dashboard_rds/main.tf
+++ b/cloudwatch_dashboard_rds/main.tf
@@ -62,7 +62,7 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", "${var.db_instance_identifier}" ]
+                    [ "AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "stat": "Maximum" } ]
                 ],
                 "region": "${var.region}",
                 "title": "CPUUtilization",
@@ -117,7 +117,7 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", "${var.db_instance_identifier}" ]
+                    [ "AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "stat": "Maximum" } ]
                 ],
                 "region": "${var.region}",
                 "yAxis": {
@@ -141,7 +141,7 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/RDS", "FreeableMemory", "DBInstanceIdentifier", "${var.db_instance_identifier}" ]
+                    [ "AWS/RDS", "FreeableMemory", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "stat": "Minimum" } ]
                 ],
                 "region": "${var.region}",
                 "yAxis": {
@@ -165,8 +165,8 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/RDS", "ReadLatency", "DBInstanceIdentifier", "${var.db_instance_identifier}" ],
-                    [ ".", "WriteLatency", ".", "." ]
+                    [ "AWS/RDS", "ReadLatency", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "stat": "Maximum" } ],
+                    [ ".", "WriteLatency", ".", ".", { "stat": "Maximum" } ]
                 ],
                 "region": "${var.region}",
                 "title": "Latency",
@@ -200,7 +200,7 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "label": "FreeStorageSpace" } ]
+                    [ "AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "label": "FreeStorageSpace", "stat": "Minimum" } ]
                 ],
                 "region": "${var.region}",
                 "title": "Disk Free",
@@ -225,7 +225,7 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/RDS", "DiskQueueDepth", "DBInstanceIdentifier", "${var.db_instance_identifier}" ]
+                    [ "AWS/RDS", "DiskQueueDepth", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "stat": "Maximum" } ]
                 ],
                 "region": "${var.region}",
                 "title": "DiskQueueDepth",
@@ -262,8 +262,8 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "AWS/RDS", "NetworkTransmitThroughput", "DBInstanceIdentifier", "${var.db_instance_identifier}" ],
-                    [ ".", "NetworkReceiveThroughput", ".", "." ]
+                    [ "AWS/RDS", "NetworkTransmitThroughput", "DBInstanceIdentifier", "${var.db_instance_identifier}", { "stat": "Maximum" } ],
+                    [ ".", "NetworkReceiveThroughput", ".", ".", { "stat": "Maximum" } ]
                 ],
                 "region": "${var.region}",
                 "yAxis": {


### PR DESCRIPTION
`dev app plan`

~~~
  # module.rds_dashboard_idp.aws_cloudwatch_dashboard.main[0] will be updated in-place
  ~ resource "aws_cloudwatch_dashboard" "main" {
      ~ dashboard_body = jsonencode(
          ~ {
              ~ widgets = [
                  ~ {
                      ~ properties = {
                          ~ metrics     = [
                              - [
                                  - "AWS/RDS",
                                  - "CPUUtilization",
                                  - "DBInstanceIdentifier",
                                  - "login-dev-idp",
                                ],
                              + [
                                  + "AWS/RDS",
                                  + "CPUUtilization",
                                  + "DBInstanceIdentifier",
                                  + "login-dev-idp",
                                  + {
                                      + stat = "Maximum"
                                    },
                                ],
                            ]
                            # (6 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                    {
                        height     = 6
                        properties = {
                            annotations = {
                                horizontal = []
                                vertical   = []
                            }
                            metrics     = [
                                [
                                    "AWS/RDS",
                                    "ReadIOPS",
                                    "DBInstanceIdentifier",
                                    "login-dev-idp",
                                    {
                                        stat = "Maximum"
                                    },
                                ],
                                [
                                    ".",
                                    "WriteIOPS",
                                    ".",
                                    ".",
                                    {
                                        stat = "Maximum"
                                    },
                                ],
                            ]
                            period      = 300
                            region      = "us-west-2"
                            stacked     = false
                            title       = "R/W IOPS"
                            view        = "timeSeries"
                            yAxis       = {
                                left  = {
                                    min = 0
                                }
                                right = {
                                    min = 0
                                }
                            }
                        }
                        type       = "metric"
                        width      = 24
                        x          = 0
                        y          = 6
                    },
                  ~ {
                      ~ properties = {
                          ~ metrics     = [
                              - [
                                  - "AWS/RDS",
                                  - "DatabaseConnections",
                                  - "DBInstanceIdentifier",
                                  - "login-dev-idp",
                                ],
                              + [
                                  + "AWS/RDS",
                                  + "DatabaseConnections",
                                  + "DBInstanceIdentifier",
                                  + "login-dev-idp",
                                  + {
                                      + stat = "Maximum"
                                    },
                                ],
                            ]
                            # (6 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ metrics     = [
                              - [
                                  - "AWS/RDS",
                                  - "FreeableMemory",
                                  - "DBInstanceIdentifier",
                                  - "login-dev-idp",
                                ],
                              + [
                                  + "AWS/RDS",
                                  + "FreeableMemory",
                                  + "DBInstanceIdentifier",
                                  + "login-dev-idp",
                                  + {
                                      + stat = "Minimum"
                                    },
                                ],
                            ]
                            # (6 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ metrics     = [
                              - [
                                  - "AWS/RDS",
                                  - "ReadLatency",
                                  - "DBInstanceIdentifier",
                                  - "login-dev-idp",
                                ],
                              - [
                                  - ".",
                                  - "WriteLatency",
                                  - ".",
                                  - ".",
                                ],
                              + [
                                  + "AWS/RDS",
                                  + "ReadLatency",
                                  + "DBInstanceIdentifier",
                                  + "login-dev-idp",
                                  + {
                                      + stat = "Maximum"
                                    },
                                ],
                              + [
                                  + ".",
                                  + "WriteLatency",
                                  + ".",
                                  + ".",
                                  + {
                                      + stat = "Maximum"
                                    },
                                ],
                            ]
                            # (6 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ metrics     = [
                              - [
                                  - "AWS/RDS",
                                  - "FreeStorageSpace",
                                  - "DBInstanceIdentifier",
                                  - "login-dev-idp",
                                  - {
                                      - label = "FreeStorageSpace"
                                    },
                                ],
                              + [
                                  + "AWS/RDS",
                                  + "FreeStorageSpace",
                                  + "DBInstanceIdentifier",
                                  + "login-dev-idp",
                                  + {
                                      + label = "FreeStorageSpace"
                                      + stat  = "Minimum"
                                    },
                                ],
                            ]
                            # (7 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ metrics     = [
                              - [
                                  - "AWS/RDS",
                                  - "DiskQueueDepth",
                                  - "DBInstanceIdentifier",
                                  - "login-dev-idp",
                                ],
                              + [
                                  + "AWS/RDS",
                                  + "DiskQueueDepth",
                                  + "DBInstanceIdentifier",
                                  + "login-dev-idp",
                                  + {
                                      + stat = "Maximum"
                                    },
                                ],
                            ]
                            # (7 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ metrics     = [
                              - [
                                  - "AWS/RDS",
                                  - "NetworkTransmitThroughput",
                                  - "DBInstanceIdentifier",
                                  - "login-dev-idp",
                                ],
                              - [
                                  - ".",
                                  - "NetworkReceiveThroughput",
                                  - ".",
                                  - ".",
                                ],
                              + [
                                  + "AWS/RDS",
                                  + "NetworkTransmitThroughput",
                                  + "DBInstanceIdentifier",
                                  + "login-dev-idp",
                                  + {
                                      + stat = "Maximum"
                                    },
                                ],
                              + [
                                  + ".",
                                  + "NetworkReceiveThroughput",
                                  + ".",
                                  + ".",
                                  + {
                                      + stat = "Maximum"
                                    },
                                ],
                            ]
                            # (6 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
            }
        )
        id             = "dev-RDS-idp"
        # (2 unchanged attributes hidden)
    }
~~~