### PR TITLE
Add variable for response hop limit

### DIFF
--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -52,6 +52,12 @@ variable "use_spot_instances" {
   default     = 0
 }
 
+variable "metadata_response_hop_limit" {
+  description = "Desired HTTP PUT response hop limit for instance metadata requests. You might need a larger hop limit for backward compatibility with container services running on the instance."
+  type = number
+  default = 1
+}
+
 # ----
 
 resource "aws_launch_template" "template" {
@@ -85,6 +91,7 @@ resource "aws_launch_template" "template" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"
+    http_put_response_hop_limit = var.metadata_response_hop_limit
   }
 
   monitoring {

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -54,8 +54,8 @@ variable "use_spot_instances" {
 
 variable "metadata_response_hop_limit" {
   description = "Desired HTTP PUT response hop limit for instance metadata requests. You might need a larger hop limit for backward compatibility with container services running on the instance."
-  type = number
-  default = 1
+  type        = number
+  default     = 1
 }
 
 # ----
@@ -89,8 +89,8 @@ resource "aws_launch_template" "template" {
   user_data = var.user_data
 
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
     http_put_response_hop_limit = var.metadata_response_hop_limit
   }
 


### PR DESCRIPTION
This is a no-op (though terraform reports a change due to the variable being previously uninitialized) per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#http_put_response_hop_limit 

Sample plan:
```
  # module.main.module.gitlab_runner_launch_template.aws_launch_template.template will be updated in-place  ~ resource "aws_launch_template" "template" {
      ~ metadata_options {
          ~ http_put_response_hop_limit = 0 -> 1
            # (3 unchanged attributes hidden)
        }
    }
```