### PR TITLE
use Terraform 1.1.3 + remove deprecated list() function from launch_template module

### DIFF
--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -137,7 +137,7 @@ resource "aws_launch_template" "template" {
       virtual_name = lookup(block_device_mappings.value, "virtual_name", null)
 
       dynamic "ebs" {
-        for_each = flatten(list(lookup(block_device_mappings.value, "ebs", [])))
+        for_each = flatten(tolist(lookup(block_device_mappings.value, "ebs", [])))
         content {
           delete_on_termination = lookup(ebs.value, "delete_on_termination", null)
           encrypted             = lookup(ebs.value, "encrypted", null)

--- a/versions.tf
+++ b/versions.tf
@@ -22,7 +22,7 @@ terraform {
       source = "newrelic/newrelic"
     }
   }
-  required_version = ">= 1.0.2"
+  required_version = ">= 1.1.3"
 }
 
 provider "aws" {


### PR DESCRIPTION
Fixes this error, which (surprisingly) was *not* coming up in earlier 1.x.x versions of Terraform (likely because of an older AWS provider version, as well):

```
│ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ])
│ syntax to write a literal list.
```