### PR TITLE
adding sts:TagSession permission for iam_masterassume module

### DIFF
--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -52,6 +52,25 @@ data "aws_iam_policy_document" "role_policy_doc" {
       ]
     }
   }
+
+  statement {
+    sid    = "${each.key}TagSessions"
+    effect = "Allow"
+    actions = [
+      "sts:TagSession"
+    ]
+    resources = [
+      for arn in each.value : arn
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+
+      values = [
+        "true",
+      ]
+    }
+  }
 }
 
 resource "aws_iam_policy" "account_role_policy" {


### PR DESCRIPTION
Allows the `session_tags=SSMSessionRunAs` line to be set in an `~/.aws/config` file, especially when used in conjunction with other `iam_` modules in this repo. Without this permission -- but with that line in place -- AWS will complain any time you try to assume a role via something like `aws-vault`:

```
aws-vault: error: exec: Failed to get credentials for <ACCOUNT>-admin: AccessDenied: User: arn:aws:iam::<REDACTED>:user/bob.smith is not authorized to perform: sts:TagSession on resource: arn:aws:iam::<REDACTED>:role/<EXAMPLE-ROLE>
```

This is part of a bigger PR/project that allows controlled access to SSM sessions/documents via tagged STS sessions; I'm opening this so that it can get merged in place without constantly having to re-`apply` (or comment out the lines in my `~/.aws/config` file) when these changes get reverted. 🙃