### PR TITLE
Try to pretty format alerts with runbook links

### DIFF
--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -28,10 +28,12 @@ locals {
             msgtext = 'auto-terraform:  ' + data['detail']['pipeline'] + ' pipeline ' + data['detail']['state'] + ' with execution ID ' + data['detail']['execution-id']
           elif 'AlarmName' in data and 'AlarmDescription' in data:
             blocks = [
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": f'*Alarm has gone off!* {data["AlarmName"]}',
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": f'*Alarm has gone off!* {data["AlarmName"]}',
+                },
               },
             ]
 

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -32,7 +32,7 @@ locals {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": f'*Alarm has gone off!* {data["AlarmName"]}',
+                  "text": f'*Alarm has gone off!*\n*{data["AlarmName"]}*',
                 },
               },
             ]
@@ -52,7 +52,7 @@ locals {
                 "text": {
                   "type": "plain_text",
                   "text": "View Runbook :books:",
-                  "emoji": true
+                  "emoji": True
                 },
                 "value": "runbook-id",
                 "url": runbook_url,
@@ -60,7 +60,7 @@ locals {
               }
 
               description_no_runbook = data["AlarmDescription"].split('Runbook:')[0]
-              blocks[0]["text"] += f'\n_{description_no_runbook}_'
+              blocks[0]["text"]["text"] += f'\n{description_no_runbook}'
             else:
               blocks.append({
                 "type": "section",
@@ -91,7 +91,7 @@ locals {
               f'*Region*: {data["Region"]}'])
           else:
             msgtext = eventmsg
-        except:
+        except Exception as e:
           msgtext = eventmsg
         msg = {
             "channel": slackChannel,

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -21,7 +21,7 @@ locals {
     def lambda_handler(event, context):
         url = parameter['Parameter']['Value']
         eventmsg = event['Records'][0]['Sns']['Message']
-        blocks = null
+        blocks = None
         try:
           data = json.loads(eventmsg)
           if 'detailType' in data and data['detailType'] == 'CodePipeline Pipeline Execution State Change':
@@ -77,8 +77,9 @@ locals {
                 "text": '\n'.join([
                   data["NewStateReason"],
                   f'*Time*: {formatted_time}',
-                  f'*Region*: {data["Region"]}'])
-                ])
+                  f'*Region*: {data["Region"]}'
+                ]),
+              }
             })
 
             msgtext = '\n'.join([

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -7,6 +7,9 @@ locals {
     import urllib3
     import json
     import os
+    import re
+    import datetime
+
     ssm = boto3.client('ssm')
     slackChannel = os.environ['slack_channel']
     slackUsername = os.environ['slack_username']
@@ -14,20 +17,74 @@ locals {
     slackUrlParam = os.environ['slack_webhook_url_parameter']
     parameter = ssm.get_parameter(Name=slackUrlParam, WithDecryption=True)
     http = urllib3.PoolManager()
+
     def lambda_handler(event, context):
         url = parameter['Parameter']['Value']
         eventmsg = event['Records'][0]['Sns']['Message']
+        blocks = null
         try:
           data = json.loads(eventmsg)
           if 'detailType' in data and data['detailType'] == 'CodePipeline Pipeline Execution State Change':
             msgtext = 'auto-terraform:  ' + data['detail']['pipeline'] + ' pipeline ' + data['detail']['state'] + ' with execution ID ' + data['detail']['execution-id']
           elif 'AlarmName' in data and 'AlarmDescription' in data:
+            blocks = [
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": f'*Alarm has gone off!* {data["AlarmName"]}',
+              },
+            ]
+
+            try:
+              iso_time = datetime.fromisoformat(data["StateChangeTime"].replace("+0000", "+00:00"))
+              formatted_time = iso_time.strftime("%Y-%m-%d %H:%M:%S %Z")
+            except:
+              formatted_time = data["StateChangeTime"]
+
+            match = re.search(r'Runbook: (https://\S+)', data["AlarmDescription"])
+            if match:
+              runbook_url = match.group(1)
+
+              blocks[0]["accessory"] = {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "View Runbook :books:",
+                  "emoji": true
+                },
+                "value": "runbook-id",
+                "url": runbook_url,
+                "action_id": "button-action",
+              }
+
+              description_no_runbook = data["AlarmDescription"].split('Runbook:')[0]
+              blocks[0]["text"] += f'\n_{description_no_runbook}_'
+            else:
+              blocks.append({
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": data["AlarmDescription"],
+                },
+              })
+
+            blocks.append({
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": '\n'.join([
+                  data["NewStateReason"],
+                  f'*Time*: {formatted_time}',
+                  f'*Region*: {data["Region"]}'])
+                ])
+            })
+
             msgtext = '\n'.join([
               '*Alarm has gone off!*',
               f'*{data["AlarmName"]}*',
               data["AlarmDescription"],
               data["NewStateReason"],
-              f'*Time*: {data["StateChangeTime"]}',
+              f'*Time*: {formatted_time}',
               f'*Region*: {data["Region"]}'])
           else:
             msgtext = eventmsg
@@ -37,13 +94,16 @@ locals {
             "channel": slackChannel,
             "username": slackUsername,
             "text": msgtext,
-            "icon_emoji": slackIcon
+            "icon_emoji": slackIcon,
         }
+        if blocks:
+          msg["blocks"] = blocks
+
         encoded_msg = json.dumps(msg).encode('utf-8')
         resp = http.request('POST',url, body=encoded_msg)
         print({
-            "message": event['Records'][0]['Sns']['Message'], 
-            "status_code": resp.status, 
+            "message": event['Records'][0]['Sns']['Message'],
+            "status_code": resp.status,
             "response": resp.data
         })
   EOT


### PR DESCRIPTION
I had some extra cycles so I wanted to try my hand at making our Slack alerts less visually noisy. I think the problem is the formatting of the `NewStateReason` from Cloudwatch

I wasn't sure exactly how to test this, since it looks like these lambdas are global for sandbox... but if all goes well, according to the [Slack BlockKit Editor](https://app.slack.com/block-kit-builder/T025AQGAN#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Alarm%20has%20gone%20off*:%20prod%20IDP%20Workers%20Failure%20Alert%5Cn_This%20alarm%20is%20executed%20when%20a%20worker%20job%20fails_%22%7D,%22accessory%22:%7B%22type%22:%22button%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22View%20Runbook%20:books:%22,%22emoji%22:true%7D,%22value%22:%22runbook-id%22,%22url%22:%22https://github.com/18F/identity-devops/wiki/Runbook:-Asynchronous-Workers%22,%22action_id%22:%22button-action%22%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22Threshold%20Crossed:%201%20out%20of%20the%20last%201%20datapoints%20%5B1.0%20(25/02/22%2000:00:00)%5D%20was%20greater%20than%20or%20equal%20to%20the%20threshold%20(1.0)%20(minimum%201%20datapoint%20for%20OK%20-%3E%20ALARM%20transition).%5Cn*Time*:%202022-02-25%2000:01:31%20UTC%5Cn*Region*:%20US%20West%20(Oregon)%22%7D%7D%5D%7D) this should be formatted like:

| before | after |
| --- | --- |
| <img width="877" alt="Screen Shot 2022-02-24 at 4 11 08 PM" src="https://user-images.githubusercontent.com/458784/155628697-032e868d-ed67-4fbd-88bf-4d9d1934c355.png"> | <img width="743" alt="Screen Shot 2022-02-24 at 4 10 44 PM" src="https://user-images.githubusercontent.com/458784/155628709-97c444ab-95f0-461a-b995-8b7245030601.png"> |

Changes:
- Grab runbook URLs and put them in a button
- Slightly format the datetime

Alternatives:
- I also looked into having a simple message and post details in a threaded reply. This would need us to use the `slack.postMessage` API, because the webhook response is just `"ok"` and doesn't contain the thread ID we'd need to post to. The `slack.postMessage` API also seems to have different channel permissions than webhooks, so that seems not good as a drop-in solution
- Find a way to simplify `NewStateReason`
- Leave it as-is! My feelings are not hurt if we close this out