### PR TITLE
restore every_one_day rule due to EventBridge quotas

### DIFF
--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -95,9 +95,14 @@ resource "aws_lambda_function" "windowed_slo" {
   }
 }
 
-# rule/every-one-day in CloudWatch is account-specific vs env-specific
+resource "aws_cloudwatch_event_rule" "every_one_day" {
+  name_prefix         = "every-one-day"
+  description         = "Fires every day"
+  schedule_expression = "rate(1 day)"
+}
+
 resource "aws_cloudwatch_event_target" "check_foo_every_one_day" {
-  rule      = var.every_one_day_rule
+  rule      = aws_cloudwatch_event_rule.every_one_day.name
   target_id = aws_lambda_function.windowed_slo.id
   arn       = aws_lambda_function.windowed_slo.arn
 }
@@ -107,10 +112,5 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_windowed_slo" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.windowed_slo.function_name
   principal     = "events.amazonaws.com"
-  source_arn = join(":", [
-    "arn:aws:events:${data.aws_region.current.name}",
-    data.aws_caller_identity.current.account_id,
-    "rule/${var.every_one_day_rule}"
-    ]
-  )
+  source_arn    = aws_cloudwatch_event_rule.every_one_day.arn
 }

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -96,7 +96,7 @@ resource "aws_lambda_function" "windowed_slo" {
 }
 
 resource "aws_cloudwatch_event_rule" "every_one_day" {
-  name_prefix         = "every-one-day"
+  name                = "every-one-day_${local.name}"
   description         = "Fires every day"
   schedule_expression = "rate(1 day)"
 }

--- a/slo_lambda/src/windowed_slo_test.py
+++ b/slo_lambda/src/windowed_slo_test.py
@@ -1,0 +1,75 @@
+import datetime
+import os
+import boto3
+import pytest
+from botocore.stub import Stubber, ANY
+
+os.environ['WINDOW_DAYS'] = '24'
+os.environ['SLI_NAMESPACE'] = 'test/sli'
+os.environ['LOAD_BALANCER_ARN'] = 'arn:aws:elasticloadbalancing:us-west-2:123:loadbalancer/app/login-idp-alb-prod/1234'
+os.environ['SLI_PREFIX'] = 'test'
+
+from windowed_slo import create_slis, SLI, METRICS
+
+def get_metric_statistics(metric_name, datapoints_sum):
+    return [
+        'get_metric_statistics',
+        {
+            'Datapoints': [
+                {'Sum': datapoints_sum}
+            ]
+        },
+        {
+            'Dimensions': [{'Name': 'LoadBalancer',
+                            'Value': 'app/login-idp-alb-prod/1234'}],
+            'EndTime': ANY,
+            'MetricName': metric_name,
+            'Namespace': 'AWS/ApplicationELB',
+            'Period': 2073600,
+            'StartTime': ANY,
+            'Statistics': ['Sum']
+        },
+    ]
+
+def put_metric_data(metric_name, value):
+    return [
+        'put_metric_data',
+        {},
+        {
+            'MetricData': [{'MetricName': metric_name,
+                            'Value': value}],
+            'Namespace': 'test/sli'
+        },
+    ]
+
+def test_simple_sli():
+    cw = boto3.client('cloudwatch')
+    with Stubber(cw) as stubber:
+        stubber.add_response(*get_metric_statistics('HTTPCode_Target_2XX_Count', 2))
+        stubber.add_response(*get_metric_statistics('RequestCount', 4))
+        stubber.add_response(*put_metric_data('test-http-200-availability', 0.5))
+        slis = {
+            'http_200_availability': SLI(
+                "http-200-availability",
+                METRICS['target_200s'],
+                METRICS['request_count'],
+            ),
+        }
+        create_slis(cw, slis)
+
+def test_multiple_metric_sli():
+    cw = boto3.client('cloudwatch')
+    with Stubber(cw) as stubber:
+        stubber.add_response(*get_metric_statistics('RequestCount', 4))
+        stubber.add_response(*get_metric_statistics('HTTPCode_ELB_5XX_Count', 2))
+        stubber.add_response(*get_metric_statistics('HTTPCode_Target_5XX_Count', 1))
+        stubber.add_response(*get_metric_statistics('RequestCount', 4))
+        stubber.add_response(*put_metric_data('test-all-availability', 0.25))
+        slis = {
+            'all_availability': SLI(
+                "all-availability",
+                METRICS['backend_success'],
+                METRICS['request_count'],
+            ),
+        }
+        create_slis(cw, slis)

--- a/slo_lambda/variables.tf
+++ b/slo_lambda/variables.tf
@@ -7,15 +7,6 @@ variable "env_name" {
   type        = string
 }
 
-variable "every_one_day_rule" {
-  description = <<EOM
-Name of a CloudWatch Event Rule with schedule_expression:rate(1 day) configured
-at the account (vs. environment) level.
-EOM
-  type        = string
-  default     = "every-one-day"
-}
-
 variable "lambda_runtime" {
   description = "Lambda runtime"
   type        = string


### PR DESCRIPTION
Surprisingly, [EventBridge rules have a quota of ***5 targets per rule***](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-quota.html#eb-limits), so account-wide rules don't work with all of the env-specific targets from `cloudwatch_sli/slo_lambda`:

```
│ Error: Creating EventBridge Target failed: LimitExceededException: The requested resource exceeds the maximum number allowed.
```

This PR thus brings the `aws_cloudwatch_event_rule.every_one_day` back into the `slo_lambda` module, using the Lambda function name as an identifier in the name, and also re-adds `windowed_slo_test.py` which @akrito was using for development/testing.