### PR TITLE
comprehensively-redesigned ssm module + accompanying updates to related iam_* modules

### DIFF
--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -79,12 +79,13 @@ data "aws_iam_policy_document" "role_policy_doc" {
         "true",
       ]
     }
+
     condition {
-      test     = "Null"
-      variable = "aws:PrincipalTag/${var.username_tag}"
+      test     = "StringEquals"
+      variable = "aws:RequestTag/SSMSessionRunAs"
 
       values = [
-        "false",
+        "&{aws:PrincipalTag/${var.username_tag}}",
       ]
     }
   }

--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -10,6 +10,15 @@ variable "role_list" {
   type        = list(any)
 }
 
+variable "username_tag" {
+  type        = string
+  default     = "ec2_username"
+  description = <<EOM
+Name of an AWS tag used to assign a username (for SSM access via SSMSessionRunAs tags)
+to an AWS user. Defaults to 'ec2_username' as per the iam_masterusers module.
+EOM
+}
+
 locals {
   # Build an enumerated map of "ACCOUNT_TYPEAssumeROLE" elements
   # to build policy documents and policies from.
@@ -68,6 +77,14 @@ data "aws_iam_policy_document" "role_policy_doc" {
 
       values = [
         "true",
+      ]
+    }
+    condition {
+      test     = "Null"
+      variable = "aws:PrincipalTag/${var.username_tag}"
+
+      values = [
+        "false",
       ]
     }
   }

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -22,6 +22,9 @@ resource "aws_iam_user" "master_user" {
 
   name          = each.key
   force_destroy = true
+  tags = element(lookup(each.value, "ec2_username", [""]), 0) == "" ? {} : {
+    ec2_username = element(each.value["ec2_username"], 0)
+  }
 }
 
 resource "aws_iam_group_membership" "master_group" {

--- a/ssm/README.md
+++ b/ssm/README.md
@@ -1,6 +1,88 @@
-# SSM
-Enables SSM IAM instance profiles to allow for directly accessing hosts
-without requiring jumphosts.
+# `ssm`
 
-# References
-* [Official Documentation] (https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-create-iam-instance-profile.html)
+This Terraform module is used to create SSM Documents for connecting to and running commands on AWS EC2 instances. Along with the documents themselves, this module creates:
+
+1. An S3 bucket, and CloudWatch log group, for storing logs of SSM sessions (see note below) -- the S3 bucket is configured using [the `s3_config` module](https://github.com/18F/identity-terraform/tree/main/s3_config) from this repo
+2. A second CloudWatch log group for logging when, and by whom, any given SSM document is used (via a CloudWatch event rule)
+3. A KMS key + alias for encrypting the above resources (logs/bucket/objects), as well as the SSM sessions themselves
+4. An IAM policy document (as a `data` source) that can be attached to EC2 instances, providing access to SSM Control/Data Channels, S3/CloudWatch, and KMS encryption -- all necessary permissions for starting document-based SSM sessions
+
+*NOTE: EC2 instances must have the [SSM Agent installed and configured](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-install-ssm-agent.html) in order to connect to them with the SSM documents created with this module.*
+
+## Schema
+
+SSM documents are created from individual object blocks within the `ssm_doc_map` variable, e.g.:
+
+```
+    "sudo" = {
+      command     = "sudo su -"
+      description = "Login and change to root user"
+      logging     = false
+    },
+```
+In this example:
+- The resulting SSM document will be named `<ENV>-ssm-document-sudo`
+- Starting a session using this document is done via `aws ssm start-session --document <ENV>-ssm-document-sudo`
+- Session data will NOT be logged to the console, as `logging = false` (see note below)
+
+## Optional: Logging SSM Sessions
+
+Each document declared in `ssm_doc_map` has an option, `logging`, which specifies whether or not to log the actual SSM sessions themselves. When set to `true`, the following is included in the `inputs` section of the document content:
+
+```yaml
+s3BucketName: "${aws_s3_bucket.ssm_logs.id}"
+s3EncryptionEnabled: true
+cloudWatchLogGroupName: "${aws_cloudwatch_log_group.ssm_session_logs.name}"
+cloudWatchEncryptionEnabled: true
+cloudWatchStreamingEnabled: true
+```
+
+If enabled, this means _everything_ that is printed to the console, i.e. commands run, output/error output, etc. will be logged to S3 and CloudWatch logs. As there may be cases where logging this data is undesirable -- e.g. when running commands on an instance that may print PII to the console -- this option can be set to `false`, which will change the above `inputs` to:
+
+```yaml
+s3EncryptionEnabled: false
+cloudWatchEncryptionEnabled: false
+```
+
+In particular, `logging` should almost always be set to `false` for any SSM documents that start an interactive session/drop the user into a shell.
+
+## Example
+
+```hcl
+module "ssm" {
+  source = "github.com/18F/identity-terraform//ssm?ref=main"
+
+  bucket_name_prefix = "login-gov"
+  region             = var.region
+  env_name           = var.env_name
+
+  ssm_doc_map = {
+    "default" = {
+      command     = "/bin/bash"
+      description = "Default shell to login"
+      logging     = false
+    },
+    "sudo" = {
+      command     = "sudo su -"
+      description = "Login and change to root user"
+      logging     = false
+    },
+    "tail-cw" = {
+      command     = "sudo tail -f /var/log/cloud-init-output.log"
+      description = "Tail the cloud-init-output logs"
+      logging     = true
+  }
+}
+```
+
+## Variables
+
+| Name                    | Type                 | Description                                                                                                                                                                          | Required | Default                                                                                                                             |
+| -----                   | -----                | -----                                                                                                                                                                                | -----    | -----                                                                                                                               |
+| `ssm_doc_map`           | **map(map(string))** | Map of data for SSM documents | YES      | <pre>{<br> 'default' = {<br>  description = 'Login shell'<br>  command   = 'cd ; /bin/bash'<br>  logging   = true<br> },<br>}</pre> |
+| `session_timeout`       | **number**           | Amount of time (in minutes) of inactivity to allow before a session ends                                                                                                            | YES      | 15                                                                                                                                  |
+| `region`                | **string**           | AWS Region                                                                                                                                                                          | YES      |                                                                                                                                     |
+| `env_name`              | **string**           | Environment name                                                                                                                                                                    | YES      |                                                                                                                                     |
+| `bucket_name_prefix`    | **string**           | First substring in S3 bucket name                                                                                                                                                   | YES      |                                                                                                                                     |
+| `log_bucket_name`       | **string**           | Override name of the bucket used for S3 logging                                                                                                                                     | NO       | <blank>                                                                                                                             |
+| `inventory_bucket_name` | **string**           | Override name of the S3 bucket used for S3 Inventory reports                                                                                                                        | NO       | <blank>                                                                                                                             |

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=7e11ebe24e3a9cbc34d1413cf4d20b3d71390d5b"
+  source = "github.com/18F/identity-terraform//s3_config?ref=a6261020a94b77b08eedf92a068832f21723f7a2"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "${var.env_name}-ssm-logs"
@@ -181,19 +181,10 @@ data "aws_iam_policy_document" "ssm_access_role_policy" {
     sid = "KMSDecryptionAccess"
     actions = [
       "kms:Decrypt",
-    ]
-    resources = [
-      aws_kms_key.kms_ssm.arn
-    ]
-  }
-
-  statement {
-    sid = "KMSDataKeyAccess"
-    actions = [
       "kms:GenerateDataKey",
     ]
     resources = [
-      "*"
+      aws_kms_key.kms_ssm.arn
     ]
   }
 }

--- a/ssm/outputs.tf
+++ b/ssm/outputs.tf
@@ -1,0 +1,9 @@
+output "ssm_access_role_policy" {
+  description = "Body of the ssm_access_role_policy, in JSON"
+  value       = data.aws_iam_policy_document.ssm_access_role_policy.json
+}
+
+output "ssm_cw_logs" {
+  description = "Name of the CloudWatch Log Group for SSM access logging."
+  value       = aws_cloudwatch_log_group.cw_ssm_logs.name
+}

--- a/ssm/outputs.tf
+++ b/ssm/outputs.tf
@@ -3,7 +3,12 @@ output "ssm_access_role_policy" {
   value       = data.aws_iam_policy_document.ssm_access_role_policy.json
 }
 
-output "ssm_cw_logs" {
+output "ssm_session_logs" {
   description = "Name of the CloudWatch Log Group for SSM access logging."
-  value       = aws_cloudwatch_log_group.cw_ssm_logs.name
+  value       = aws_cloudwatch_log_group.ssm_session_logs.name
+}
+
+output "ssm_cmd_logs" {
+  description = "Name of the CloudWatch Log Group for SSM command logging."
+  value       = aws_cloudwatch_log_group.ssm_cmd_logs.name
 }

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -12,6 +12,15 @@ EOM
   }
 }
 
+variable "session_timeout" {
+  description = <<EOM
+REQUIRED. Amount of time (in minutes) of inactivity
+to allow before a session ends.
+EOM
+  type        = number
+  default     = 15
+}
+
 variable "region" {
   description = "REQUIRED. AWS Region"
   type        = string
@@ -61,6 +70,4 @@ locals {
   inventory_bucket = var.inventory_bucket_name != "" ? var.inventory_bucket_name : join(".",
     [var.bucket_name_prefix, "s3-inventory", local.bucket_name_suffix]
   )
-
-  ssm_kms_keys = ["s3", "sessions"]
 }

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -1,13 +1,15 @@
 variable "ssm_doc_map" {
   description = <<EOM
-REQUIRED. Map of data for SSM Documents. Each must include
-the document name, description, and command(s) to run at login.
+REQUIRED. Map of data for SSM Documents. Each must include the
+document name, description, command(s) to run at login, and
+whether to log the commands/output from the given session/document.
 EOM
   type        = map(map(string))
   default = {
     "default" = {
       description = "Default login shell"
       command     = "cd ; /bin/bash"
+      logging     = true
     },
   }
 }

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -7,9 +7,9 @@ EOM
   type        = map(map(string))
   default = {
     "default" = {
-      description = "Default login shell"
+      description = "Login shell"
       command     = "cd ; /bin/bash"
-      logging     = true
+      logging     = false
     },
   }
 }

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -1,0 +1,66 @@
+variable "ssm_doc_map" {
+  description = <<EOM
+REQUIRED. Map of data for SSM Documents. Each must include
+the document name, description, and command(s) to run at login.
+EOM
+  type        = map(map(string))
+  default = {
+    "default" = {
+      description = "Default login shell"
+      command     = "cd ; /bin/bash"
+    },
+  }
+}
+
+variable "region" {
+  description = "REQUIRED. AWS Region"
+  type        = string
+}
+
+variable "env_name" {
+  description = "REQUIRED. Environment name"
+  type        = string
+}
+
+variable "bucket_name_prefix" {
+  description = <<EOM
+REQUIRED. First substring in S3 bucket name of
+$bucket_name_prefix.$env_name-ssm-logs.$account_id-$region
+EOM
+  type        = string
+}
+
+variable "log_bucket_name" {
+  description = <<EOM
+(OPTIONAL) Override name of the bucket used for S3 logging.
+Will default to $bucket_name_prefix.s3-access-logs.$account_id-$region
+if not explicitly declared.
+EOM
+  type        = string
+  default     = ""
+}
+
+variable "inventory_bucket_name" {
+  description = <<EOM
+(OPTIONAL) Override name of the S3 bucket used for S3 Inventory reports.
+Will default to $bucket_name_prefix.s3-inventory.$account_id-$region
+if not explicitly declared.
+EOM
+  type        = string
+  default     = ""
+}
+
+locals {
+  bucket_name_suffix = "${data.aws_caller_identity.current.account_id}-${var.region}"
+  s3_bucket_name     = "${var.bucket_name_prefix}.${var.env_name}-ssm-logs.${local.bucket_name_suffix}"
+
+  log_bucket = var.log_bucket_name != "" ? var.log_bucket_name : join(".",
+    [var.bucket_name_prefix, "s3-access-logs", local.bucket_name_suffix]
+  )
+
+  inventory_bucket = var.inventory_bucket_name != "" ? var.inventory_bucket_name : join(".",
+    [var.bucket_name_prefix, "s3-inventory", local.bucket_name_suffix]
+  )
+
+  ssm_kms_keys = ["s3", "sessions"]
+}


### PR DESCRIPTION
_(This information is pulled directly from the `README` for the `ssm` module.)_

The `ssm` Terraform module is used to create SSM Documents for connecting to and running commands on AWS EC2 instances. Along with the documents themselves, this module creates:

1. An S3 bucket, and CloudWatch log group, for storing logs of SSM sessions (see note below) -- the S3 bucket is configured using [the `s3_config` module](https://github.com/18F/identity-terraform/tree/main/s3_config) from this repo
2. A second CloudWatch log group for logging when, and by whom, any given SSM document is used (via a CloudWatch event rule)
3. A KMS key + alias for encrypting the above resources (logs/bucket/objects), as well as the SSM sessions themselves
4. An IAM policy document (as a `data` source) that can be attached to EC2 instances, providing access to SSM Control/Data Channels, S3/CloudWatch, and KMS encryption -- all necessary permissions for starting document-based SSM sessions

*NOTE: EC2 instances must have the [SSM Agent installed and configured](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-install-ssm-agent.html) in order to connect to them with the SSM documents created with this module.*

## Schema

SSM documents are created from individual object blocks within the `ssm_doc_map` variable, e.g.:

```
    "sudo" = {
      command     = "sudo su -"
      description = "Login and change to root user"
      logging     = false
    },
```
In this example:
- The resulting SSM document will be named `<ENV>-ssm-document-sudo`
- Starting a session using this document is done via `aws ssm start-session --document <ENV>-ssm-document-sudo`
- Session data will NOT be logged to the console, as `logging = false` (see note below)

## Optional: Logging SSM Sessions

Each document declared in `ssm_doc_map` has an option, `logging`, which specifies whether or not to log the actual SSM sessions themselves. When set to `true`, the following is included in the `inputs` section of the document content:

```yaml
s3BucketName: "${aws_s3_bucket.ssm_logs.id}"
s3EncryptionEnabled: true
cloudWatchLogGroupName: "${aws_cloudwatch_log_group.ssm_session_logs.name}"
cloudWatchEncryptionEnabled: true
cloudWatchStreamingEnabled: true
```

If enabled, this means _everything_ that is printed to the console, i.e. commands run, output/error output, etc. will be logged to S3 and CloudWatch logs. As there may be cases where logging this data is undesirable -- e.g. when running commands on an instance that may print PII to the console -- this option can be set to `false`, which will change the above `inputs` to:

```yaml
s3EncryptionEnabled: false
cloudWatchEncryptionEnabled: false
```

In particular, `logging` should almost always be set to `false` for any SSM documents that start an interactive session/drop the user into a shell.

## Example

```hcl
module "ssm" {
  source = "github.com/18F/identity-terraform//ssm?ref=main"

  bucket_name_prefix = "login-gov"
  region             = var.region
  env_name           = var.env_name

  ssm_doc_map = {
    "default" = {
      command     = "/bin/bash"
      description = "Default shell to login"
      logging     = false
    },
    "sudo" = {
      command     = "sudo su -"
      description = "Login and change to root user"
      logging     = false
    },
    "tail-cw" = {
      command     = "sudo tail -f /var/log/cloud-init-output.log"
      description = "Tail the cloud-init-output logs"
      logging     = true
  }
}
```

## Variables

| Name                    | Type                 | Description                                                                                                                                                                          | Required | Default                                                                                                                             |
| -----                   | -----                | -----                                                                                                                                                                                | -----    | -----                                                                                                                               |
| `ssm_doc_map`           | **map(map(string))** | Map of data for SSM documents | YES      | <pre>{<br> 'default' = {<br>  description = 'Login shell'<br>  command   = 'cd ; /bin/bash'<br>  logging   = true<br> },<br>}</pre> |
| `session_timeout`       | **number**           | Amount of time (in minutes) of inactivity to allow before a session ends                                                                                                            | YES      | 15                                                                                                                                  |
| `region`                | **string**           | AWS Region                                                                                                                                                                          | YES      |                                                                                                                                     |
| `env_name`              | **string**           | Environment name                                                                                                                                                                    | YES      |                                                                                                                                     |
| `bucket_name_prefix`    | **string**           | First substring in S3 bucket name                                                                                                                                                   | YES      |                                                                                                                                     |
| `log_bucket_name`       | **string**           | Override name of the bucket used for S3 logging                                                                                                                                     | NO       | <blank>                                                                                                                             |
| `inventory_bucket_name` | **string**           | Override name of the S3 bucket used for S3 Inventory reports                                                                                                                        | NO       | <blank>                                                                                                                             |