### PR TITLE
removing region-specific AWS provider aliases from versions.tf

### DIFF
--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -2,6 +2,11 @@
 
 # -- Data Sources --
 
+provider "aws" {
+  alias  = "use1"
+  region = "us-east-1"
+}
+
 data "aws_caller_identity" "current" {
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -24,13 +24,3 @@ terraform {
   }
   required_version = ">= 1.1.3"
 }
-
-provider "aws" {
-  alias  = "use1"
-  region = "us-east-1"
-}
-
-provider "aws" {
-  alias  = "usw2"
-  region = "us-west-2"
-}


### PR DESCRIPTION
While the general `terraform{}` block in `versions.tf` can be symlinked across directories, the `provider "aws"` causes conflicts when a module from this repo is called using `for_each` / `count` / etc., e.g.:

```
│ Error: Module module.main.module.slack_lambda_use1 contains provider configuration
│ 
│ Providers cannot be configured within modules using count, for_each or depends_on.

│ Error: Module module.main.module.slack_lambda_usw2 contains provider configuration
│ 
│ Providers cannot be configured within modules using count, for_each or depends_on.
```

This PR moves the provider alias block out of `versions.tf` and into `dnssec/main.tf`, as it is currently the only module in this repo that _requires_ an AWS provider in `us-east-1` (the only currently-supported region for AWS DNSSEC).