### PR TITLE
adding depends_on blocks for ssm and dnssec modules

### DIFF
--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -149,9 +149,12 @@ resource "aws_route53_key_signing_key" "dnssec" {
 }
 
 resource "aws_route53_hosted_zone_dnssec" "dnssec" {
+  # if removing/disabling DNSSEC, verify that ALL KSKs/KMS keys are gone first
   depends_on = [
-    aws_route53_key_signing_key.dnssec
+    aws_route53_key_signing_key.dnssec,
+    aws_kms_key.dnssec
   ]
+
   hosted_zone_id = var.dnssec_zone_id
 
   #lifecycle {

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -117,15 +117,13 @@ resource "aws_s3_bucket" "ssm_logs" {
 module "ssm_logs_bucket_config" {
   source = "github.com/18F/identity-terraform//s3_config?ref=a6261020a94b77b08eedf92a068832f21723f7a2"
 
-  bucket_name_prefix   = var.bucket_name_prefix
-  bucket_name          = aws_s3_bucket.ssm_logs.id
-  region               = var.region
+  bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
   depends_on           = [aws_s3_bucket.ssm_logs]
 }
 
 resource "aws_cloudwatch_log_group" "ssm_session_logs" {
-  name              = "aws-ssm-sessions-${var.env_name}" #stream name must start with "aws-ssm-sessions"
+  name              = "aws-ssm-sessions-${var.env_name}" #stream name must start with "aws-ssm-logs"
   retention_in_days = 365
   kms_key_id        = aws_kms_key.kms_ssm.arn
 }

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -118,13 +118,13 @@ module "ssm_logs_bucket_config" {
   source = "github.com/18F/identity-terraform//s3_config?ref=a6261020a94b77b08eedf92a068832f21723f7a2"
 
   bucket_name_prefix   = var.bucket_name_prefix
-  bucket_name          = "${var.env_name}-ssm-logs"
+  bucket_name          = aws_s3_bucket.ssm_logs.id
   region               = var.region
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
 }
 
 resource "aws_cloudwatch_log_group" "ssm_session_logs" {
-  name              = "aws-ssm-sessions-${var.env_name}" #stream name must start with "aws-ssm-logs"
+  name              = "aws-ssm-sessions-${var.env_name}" #stream name must start with "aws-ssm-sessions"
   retention_in_days = 365
   kms_key_id        = aws_kms_key.kms_ssm.arn
 }

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -121,6 +121,7 @@ module "ssm_logs_bucket_config" {
   bucket_name          = aws_s3_bucket.ssm_logs.id
   region               = var.region
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
+  depends_on           = [aws_s3_bucket.ssm_logs]
 }
 
 resource "aws_cloudwatch_log_group" "ssm_session_logs" {

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -119,7 +119,7 @@ module "ssm_logs_bucket_config" {
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
-  depends_on           = [aws_s3_bucket.ssm_logs]
+  depends_on           = [aws_s3_bucket.ssm_logs.arn]
 }
 
 resource "aws_cloudwatch_log_group" "ssm_session_logs" {


### PR DESCRIPTION
As per the title:

1. Updates the `dnssec` module to also depend upon the `aws_kms_key.dnssec` resource(s) before configure DNSSEC for the domain; without this additional dependency, DNSSEC can't be automatically disabled/the resource destroyed, e.g.:

```
Error: error disabling Route 53 Hosted Zone DNSSEC (Z0123456789ABCDEFGHI): KeySigningKeyInParentDSRecord: Disabling DNSSEC in hosted zone 'example.com.' will break the authentication chain. Please remove DS records in the parent zone first.
```

2. Updates the `ssm` module so that the `s3_config` block depends on `aws_s3_bucket.ssm_logs.arn`, meaning the module will wait for the bucket to exist before attempting to create the public access block/S3 Inventory configs.