### PR TITLE
use string ("false") vs. bool (false) in directive for runAs* settings in SSM documents

### DIFF
--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -119,7 +119,7 @@ module "ssm_logs_bucket_config" {
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
-  depends_on           = [aws_s3_bucket.ssm_logs.arn]
+  depends_on           = [aws_s3_bucket.ssm_logs]
 }
 
 resource "aws_cloudwatch_log_group" "ssm_session_logs" {
@@ -210,7 +210,7 @@ inputs:
   cloudWatchEncryptionEnabled: false%{endif}
   kmsKeyId: ${aws_kms_key.kms_ssm.arn}
   idleSessionTimeout: ${var.session_timeout}
-  %{if each.value["use_root"] == false}runAsEnabled: true
+  %{if each.value["use_root"] == "false"}runAsEnabled: true
   runAsDefaultUser: ''%{endif}
   shellProfile:
     linux: 'trap "exit 0" INT; ${each.value["command"]} ; exit'

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -119,7 +119,7 @@ module "ssm_logs_bucket_config" {
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
-  depends_on           = [aws_s3_bucket.ssm_logs.arn]
+  depends_on           = [aws_s3_bucket.ssm_logs]
 }
 
 resource "aws_cloudwatch_log_group" "ssm_session_logs" {

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -119,7 +119,7 @@ module "ssm_logs_bucket_config" {
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
-  depends_on           = [aws_s3_bucket.ssm_logs]
+  depends_on           = [aws_s3_bucket.ssm_logs.arn]
 }
 
 resource "aws_cloudwatch_log_group" "ssm_session_logs" {


### PR DESCRIPTION
Given the following key/value pair in a map variable, where the value is specifically declared as a bool:
```
use_root    = true
```

This directive in Terraform WILL work correctly...
```
%{if each.value["use_root"]}
```

...but ***this*** will ***NOT***:
```
%{if each.value["use_root"] == true}
```

What isn't immediately clear [from the documentation on Directives](https://www.terraform.io/language/expressions/strings#directives) is that Terraform processes boolean values of `true` / `false` as *strings*. Thus, the following directive in the `ssm` module will fail 100% of the time:

```
%{if each.value["use_root"] == false}
```

Updating the directive to look for a ***string*** (instead of a bool) corrects this issue for `ssm_doc_map` objects where `use_root = false`, as evidenced from the output of a `plan`, e.g.:

```
 # module.ssm.aws_ssm_document.ssm_cmd["default"] will be updated in-place
 ~ resource "aws_ssm_document" "ssm_cmd" {
   ~ content = <<-EOT
      ---
     -  
     +  runAsEnabled: true
     +  runAsDefaultUser: ''

 # module.ssm.aws_ssm_document.ssm_cmd["sudo"] will be updated in-place
 ~ resource "aws_ssm_document" "ssm_cmd" {
   ~ content = <<-EOT
      ---
     -  
     +  runAsEnabled: true
     +  runAsDefaultUser: ''
```

(Also, a syntax fix for the `depends_on` block in `ssm_logs_bucket_config`, to fix the following:)

```
│ Error: Invalid depends_on reference
│ 
│   on ../../../identity-terraform/ssm/main.tf line 122, in module "ssm_logs_bucket_config":
│  122:   depends_on           = [aws_s3_bucket.ssm_logs.arn]
│ 
│ References in depends_on must be to a whole object (resource, etc), not to an attribute of an object.
```