### PR TITLE
add support for govcloud in iam modules

### DIFF
--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -1,4 +1,9 @@
 # -- Variables --
+variable "partition" {
+  description = "which aws partition this is deployed in"
+  type = string
+  default = "aws"
+}
 
 variable "master_account_id" {
   description = "AWS account ID for the master account."
@@ -44,7 +49,7 @@ resource "aws_iam_policy_attachment" "group_policy" {
 
   name       = each.key
   groups     = each.value
-  policy_arn = "arn:aws:iam::${var.master_account_id}:policy/${each.key}"
+  policy_arn = "arn:${var.partition}:iam::${var.master_account_id}:policy/${each.key}"
 
   depends_on = [
     var.policy_depends_on,

--- a/iam_assumegroup/main.tf
+++ b/iam_assumegroup/main.tf
@@ -1,8 +1,8 @@
 # -- Variables --
 variable "partition" {
   description = "which aws partition this is deployed in"
-  type = string
-  default = "aws"
+  type        = string
+  default     = "aws"
 }
 
 variable "master_account_id" {

--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -1,4 +1,9 @@
 # -- Variables --
+variable "partition" {
+  description = "which aws partition this is deployed in"
+  type = string
+  default = "aws"
+}
 
 variable "aws_account_types" {
   description = "Mapping of account types to lists of AWS account numbers."
@@ -25,7 +30,7 @@ locals {
   role_expansion = {
     for rolepair in setproduct(keys(var.aws_account_types), var.role_list) : join("", [rolepair[0], "Assume", rolepair[1]]) => [
       for pair in setproduct(var.aws_account_types[rolepair[0]], [rolepair[1]]) :
-      join("", ["arn:aws:iam::", pair[0], ":role/", pair[1]])
+      join("", ["arn:${var.partition}:iam::", pair[0], ":role/", pair[1]])
     ]
   }
 }

--- a/iam_masterassume/main.tf
+++ b/iam_masterassume/main.tf
@@ -1,8 +1,8 @@
 # -- Variables --
 variable "partition" {
   description = "which aws partition this is deployed in"
-  type = string
-  default = "aws"
+  type        = string
+  default     = "aws"
 }
 
 variable "aws_account_types" {

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -1,8 +1,8 @@
 # -- Variables --
 variable "partition" {
   description = "which aws partition this is deployed in"
-  type = string
-  default = "aws"
+  type        = string
+  default     = "aws"
 }
 
 variable "user_map" {

--- a/iam_masterusers/main.tf
+++ b/iam_masterusers/main.tf
@@ -1,4 +1,9 @@
 # -- Variables --
+variable "partition" {
+  description = "which aws partition this is deployed in"
+  type = string
+  default = "aws"
+}
 
 variable "user_map" {
   description = "Map of users to group memberships."
@@ -116,7 +121,7 @@ data "aws_iam_policy_document" "manage_your_account" {
       "iam:ListGroupsForUser",
     ]
     resources = [
-      "arn:aws:iam::*:user/$${aws:username}",
+      "arn:${var.partition}:iam::*:user/$${aws:username}",
     ]
   }
   statement {
@@ -126,8 +131,8 @@ data "aws_iam_policy_document" "manage_your_account" {
       "iam:ListMFADevices",
     ]
     resources = [
-      "arn:aws:iam::*:mfa/*",
-      "arn:aws:iam::*:user/$${aws:username}",
+      "arn:${var.partition}:iam::*:mfa/*",
+      "arn:${var.partition}:iam::*:user/$${aws:username}",
     ]
   }
   statement {
@@ -140,8 +145,8 @@ data "aws_iam_policy_document" "manage_your_account" {
       "iam:ResyncMFADevice",
     ]
     resources = [
-      "arn:aws:iam::*:mfa/$${aws:username}",
-      "arn:aws:iam::*:user/$${aws:username}",
+      "arn:${var.partition}:iam::*:mfa/$${aws:username}",
+      "arn:${var.partition}:iam::*:user/$${aws:username}",
     ]
   }
   statement {
@@ -151,8 +156,8 @@ data "aws_iam_policy_document" "manage_your_account" {
       "iam:DeactivateMFADevice",
     ]
     resources = [
-      "arn:aws:iam::*:mfa/$${aws:username}",
-      "arn:aws:iam::*:user/$${aws:username}",
+      "arn:${var.partition}:iam::*:mfa/$${aws:username}",
+      "arn:${var.partition}:iam::*:user/$${aws:username}",
     ]
     condition {
       test     = "Bool"


### PR DESCRIPTION
AWS arns are unique for different partitions: 

- commercial accounts : "aws"
- govcloud: "aws-us-gov"
etc

This PR adjusts the arns in 

- Iam_assumegroup
- Iam_masterassume
- iam_masterusers

to be passed a different partition value if needed, but defaulting to the commercial 'aws' partition. 