### PR TITLE
add resource_check output to null_archive for depends_on statements

### DIFF
--- a/null_archive/README.md
+++ b/null_archive/README.md
@@ -15,6 +15,8 @@ This Terraform module uses a `null_resource` as a trigger for compressing the co
 
 `null_resource.source_hash_check` is used to monitor the Base64-encoded SHA256 hash of the main source code file, and will cause the `archive_file` resource to _always_ create a new ZIP file -- but only if updates are _actually_ made to the function's source code file.
 
+For maximum compatibility, a `depends_on` statement/list item should be used in the accompanying `aws_lambda_function` resource, pointing to the `resource_check` output, ensuring that the function _only_ updates if the `null_resource.source_hash_check` resource is triggered/replaced.
+
 ## Example
 
 ```hcl
@@ -44,6 +46,8 @@ resource "aws_lambda_function" "sample_lambda" {
       region          = data.aws_region.current.name
     }
   }
+
+  depends_on = [module.smart_archive_file.resource_check]
 }
 ```
 
@@ -57,3 +61,4 @@ resource "aws_lambda_function" "sample_lambda" {
 
 `zip_output_path` - Output path/filename of ZIP file created from source code filename.
 `zip_output_base64sha256` - base64-encoded SHA256 checksum of ZIP file.
+`resource_check` - ID (in Terraform state) of the `null_resource.source_hash_check` resource. Use with a `depends_on` block to ensure that a parent resource (e.g. a Lambda function) _only_ updates when the source code changes.

--- a/null_archive/outputs.tf
+++ b/null_archive/outputs.tf
@@ -7,3 +7,8 @@ output "zip_output_base64sha256" {
   description = "base64-encoded SHA256 checksum of ZIP file."
   value       = data.archive_file.lambda.output_base64sha256
 }
+
+output "null_resource_check" {
+  description = "ID of null_resource (changes when triggered)."
+  value       = null_resource.source_hash_check.id
+}

--- a/null_archive/outputs.tf
+++ b/null_archive/outputs.tf
@@ -8,7 +8,7 @@ output "zip_output_base64sha256" {
   value       = data.archive_file.lambda.output_base64sha256
 }
 
-output "null_resource_check" {
+output "resource_check" {
   description = "ID of null_resource (changes when triggered)."
   value       = null_resource.source_hash_check.id
 }

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=a952f2203f6a12610e847404939eefc3c23a1f02"
+  source = "github.com/18F/identity-terraform//null_archive?ref=b4eb8ffd4f46539b35b31833237d7a0413adc029"
 
   source_code_filename = "slack_lambda.py"
   source_dir           = "${path.module}/src/"
@@ -77,6 +77,8 @@ resource "aws_lambda_function" "slack_lambda" {
       slack_icon                  = var.slack_icon
     }
   }
+
+  depends_on = [module.lambda_code.resource_check]
 }
 
 resource "aws_iam_role" "slack_lambda" {

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=a952f2203f6a12610e847404939eefc3c23a1f02"
+  source = "github.com/18F/identity-terraform//null_archive?ref=b4eb8ffd4f46539b35b31833237d7a0413adc029"
 
   source_code_filename = "windowed_slo.py"
   source_dir           = "${path.module}/src/"
@@ -95,6 +95,8 @@ resource "aws_lambda_function" "windowed_slo" {
       SLI_PREFIX        = var.sli_prefix
     }
   }
+
+  depends_on = [module.lambda_zip.resource_check]
 }
 
 resource "aws_cloudwatch_event_rule" "every_one_day" {


### PR DESCRIPTION
One thing that was missed -- when shifting from a fully-contained module (i.e. one containing the Lambda function itself) into the current `null_archive` module -- was a `depends_on` block, within the parent Lambda function, that points to the resource ID of `null_resource.source_hash_check`. Without that block/list item, the Lambda would always change whenever a new `archive_file` was generated -- instead of purely looking to see if the source code had changed.

This PR adds support for a `depends_on` attribute, by way of the `resource_check` output, which resolves to the aforementioned resource ID, e.g.:

```
  depends_on = [module.smart_archive_file.resource_check]
```

It also updates the two modules within this repo -- `slo_lambda` and `slack_lambda` -- which use the `null_archive` module thusly.