### PR TITLE
remove deprecated hashicorp/template provider

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -181,7 +181,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
+  source = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -181,7 +181,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -122,7 +122,7 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -122,7 +122,7 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
+  source = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -613,7 +613,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -800,7 +800,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -613,7 +613,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -800,7 +800,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source   = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source   = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source   = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
+  source   = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=b4eb8ffd4f46539b35b31833237d7a0413adc029"
+  source = "github.com/18F/identity-terraform//null_archive?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   source_code_filename = "slack_lambda.py"
   source_dir           = "${path.module}/src/"

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source = "github.com/18F/identity-terraform//null_archive?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   source_code_filename = "slack_lambda.py"
   source_dir           = "${path.module}/src/"

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=b4eb8ffd4f46539b35b31833237d7a0413adc029"
+  source = "github.com/18F/identity-terraform//null_archive?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   source_code_filename = "windowed_slo.py"
   source_dir           = "${path.module}/src/"

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source = "github.com/18F/identity-terraform//null_archive?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   source_code_filename = "windowed_slo.py"
   source_dir           = "${path.module}/src/"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -134,7 +134,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -134,7 +134,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=a6261020a94b77b08eedf92a068832f21723f7a2"
+  source = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -299,7 +299,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
+  source     = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -299,7 +299,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=5d338480d96af4c5123fcbebb0d0a189e31496b4"
+  source     = "github.com/18F/identity-terraform//s3_config?ref=c43ffec95185aba9a5eef9324d81a6b87aab1997"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/versions.tf
+++ b/versions.tf
@@ -6,14 +6,14 @@ terraform {
     archive = {
       source = "hashicorp/archive"
     }
+    cloudinit = {
+      source = "hashicorp/cloudinit"
+    }
     external = {
       source = "hashicorp/external"
     }
     null = {
       source = "hashicorp/null"
-    }
-    template = {
-      source = "hashicorp/template"
     }
     github = {
       source = "integrations/github"


### PR DESCRIPTION
This isn't actually used in any modules within this repo, and we're removing it from the one(s) we have downstream from it. Leaving it in causes Terraform to complain when trying to use a readonly lockfile (where it's no longer present), which is even more of an incentive to remove it!