### PR TITLE
make elb_http_alerts module support multiple Load Balancers/types

### DIFF
--- a/elb_http_alerts/README.md
+++ b/elb_http_alerts/README.md
@@ -1,3 +1,27 @@
-# ELB alerts
+# `elb_http_alerts`
 
-This module uses AWS-provided metrics and creates alarms for HTTP/5xx results.
+This Terraform module uses AWS-provided metrics from Load Balancers, and creates CloudWatch alarms for HTTP/5XX errors. It supports both Classic and Application Load Balancers, and creates alarms for both the Load Balancer itself and for attached targets/instances.
+
+## Example
+
+```hcl
+module "elb_http_alerts" {
+  source = "github.com/18F/identity-terraform//elb_http_alerts?ref=main"
+
+  env_name = var.env_name
+  lb_name  = aws_alb.idp.name
+  lb_type  = "ALB"
+
+  // These are defined in variables.tf
+  alarm_actions = local.high_priority_alarm_actions
+}
+```
+
+## Variables
+
+- `env_name` - Environment name, for prefixing the generated metric names.
+- `lb_name` - Name of the Load Balancer.
+- `lb_type` - Type of Load Balancer (ELB or ALB).
+- `alarm_actions` - A list of ARNs to notify when the LB alarms fire.
+- `lb_threshold` - Number of errors to trigger LB 5xx alarm.
+- `target_threshold` - Number of errors to trigger targets/instances 5xx alarm.

--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -33,7 +33,7 @@ variable "target_threshold" {
 }
 
 locals {
-  elb_type_data = {
+  lb_type_data = {
     ALB = {
       "namespace"     = "AWS/ApplicationELB",
       "lb_metric"     = "HTTPCode_ELB_5XX_Count",
@@ -51,9 +51,11 @@ locals {
 
 resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
   alarm_name        = "${var.lb_name} ${var.lb_type} HTTP 5XX"
-  alarm_description = "HTTP 5XX errors served by ${var.lb_type} without hosts [TF]"
-  namespace         = lookup(local.elb_type_data, var.lb_type)["namespace"]
-  metric_name       = lookup(local.elb_type_data, var.lb_type)["lb_metric"]
+  alarm_description = <<EOM
+HTTP 5XX errors served by the ${var.lb_name} ${var.lb_type} without hosts
+EOM
+  namespace         = lookup(local.lb_type_data, var.lb_type)["namespace"]
+  metric_name       = lookup(local.lb_type_data, var.lb_type)["lb_metric"]
   dimensions = {
     LoadBalancer = var.lb_name
   }
@@ -76,9 +78,11 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
 
 resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
   alarm_name        = "${var.lb_name} Target HTTP 5XX"
-  alarm_description = "HTTP 5XX errors served by hosts in ${var.lb_type} [TF]"
-  namespace         = lookup(local.elb_type_data, var.lb_type)["namespace"]
-  metric_name       = lookup(local.elb_type_data, var.lb_type)["target_metric"]
+  alarm_description = <<EOM
+HTTP 5XX errors served by hosts in ${var.lb_name} ${var.lb_type}
+EOM
+  namespace         = lookup(local.lb_type_data, var.lb_type)["namespace"]
+  metric_name       = lookup(local.lb_type_data, var.lb_type)["target_metric"]
   dimensions = {
     LoadBalancer = var.lb_name
   }

--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -11,23 +11,24 @@ variable "lb_name" {
 }
 
 variable "lb_type" {
-  description = "Type of Load Balancer (ELB, ALB, or NLB)"
+  description = "Type of Load Balancer (ELB or ALB)"
   type        = string
-  default     = "ELB"
 }
 
 variable "alarm_actions" {
-  type        = list(string)
   description = "A list of ARNs to notify when the LB alarms fire"
+  type        = list(string)
 }
 
 variable "lb_threshold" {
   description = "Number of errors to trigger LB 5xx alarm"
+  type        = number
   default     = 30
 }
 
 variable "target_threshold" {
   description = "Number of errors to trigger targets/instances 5xx alarm"
+  type        = number
   default     = 150
 }
 

--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -1,38 +1,65 @@
+# -- Variables --
+
 variable "env_name" {
   description = "Environment name, for prefixing the generated metric names"
+  type        = string
 }
 
-variable "load_balancer_id" {
-  description = "ID of the IDP load balancer"
+variable "lb_name" {
+  description = "Name of the Load Balancer"
+  type        = string
+}
+
+variable "lb_type" {
+  description = "Type of Load Balancer (ELB, ALB, or NLB)"
+  type        = string
+  default     = "ELB"
 }
 
 variable "alarm_actions" {
   type        = list(string)
-  description = "A list of ARNs to notify when the ELB alarms fire"
+  description = "A list of ARNs to notify when the LB alarms fire"
 }
 
-variable "elb_threshold" {
-  description = "Number of errors to trigger ELB 5xx alarm"
+variable "lb_threshold" {
+  description = "Number of errors to trigger LB 5xx alarm"
   default     = 30
 }
 
 variable "target_threshold" {
-  description = "Number of errors to trigger target 5xx alarm"
+  description = "Number of errors to trigger targets/instances 5xx alarm"
   default     = 150
 }
 
+locals {
+  elb_type_data = {
+    ALB = {
+      namespace     = "AWS/ApplicationELB",
+      lb_metric     = "HTTPCode_ELB_5XX_Count",
+      target_metric = "HTTPCode_Target_5XX_Count"
+    },
+    ELB = {
+      namespace     = "AWS/ELB",
+      b_metric      = "HTTPCode_ELB_5XX",
+      target_metric = "HTTPCode_Backend_5XX"
+    }
+  }
+}
+
+# -- Resources --
+
 resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
-  alarm_name        = "${var.env_name} IDP ELB HTTP 5XX"
-  alarm_description = "HTTP 5XX errors served by the ELB without the IDP [TF]"
-  namespace         = "AWS/ApplicationELB"
-  metric_name       = "HTTPCode_ELB_5XX_Count"
+  alarm_name        = "${var.lb_name} ${var.lb_type} HTTP 5XX"
+  alarm_description = "HTTP 5XX errors served by ${var.lb_type} without hosts [TF]"
+  namespace         = lookup(local.elb_type_data, var.lb_type)["namespace"]
+  metric_name       = lookup(local.elb_type_data, var.lb_type)["lb_metric"]
   dimensions = {
-    LoadBalancer = var.load_balancer_id
+    LoadBalancer = var.lb_name
   }
 
   statistic           = "Sum"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = var.elb_threshold
+  threshold           = var.lb_threshold
   period              = 60
   datapoints_to_alarm = 1
   evaluation_periods  = 1
@@ -43,12 +70,12 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
-  alarm_name        = "${var.env_name} IDP Target HTTP 5XX"
-  alarm_description = "HTTP 5XX errors served by IDP [TF]"
-  namespace         = "AWS/ApplicationELB"
-  metric_name       = "HTTPCode_Target_5XX_Count"
+  alarm_name        = "${var.lb_name} Target HTTP 5XX"
+  alarm_description = "HTTP 5XX errors served by hosts in ${var.lb_type} [TF]"
+  namespace         = lookup(local.elb_type_data, var.lb_type)["namespace"]
+  metric_name       = lookup(local.elb_type_data, var.lb_type)["target_metric"]
   dimensions = {
-    LoadBalancer = var.load_balancer_id
+    LoadBalancer = var.lb_name
   }
 
   statistic           = "Sum"

--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -34,14 +34,14 @@ variable "target_threshold" {
 locals {
   elb_type_data = {
     ALB = {
-      namespace     = "AWS/ApplicationELB",
-      lb_metric     = "HTTPCode_ELB_5XX_Count",
-      target_metric = "HTTPCode_Target_5XX_Count"
+      "namespace"     = "AWS/ApplicationELB",
+      "lb_metric"     = "HTTPCode_ELB_5XX_Count",
+      "target_metric" = "HTTPCode_Target_5XX_Count"
     },
     ELB = {
-      namespace     = "AWS/ELB",
-      b_metric      = "HTTPCode_ELB_5XX",
-      target_metric = "HTTPCode_Backend_5XX"
+      "namespace"     = "AWS/ELB",
+      "lb_metric"     = "HTTPCode_ELB_5XX",
+      "target_metric" = "HTTPCode_Backend_5XX"
     }
   }
 }
@@ -67,6 +67,10 @@ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
   treat_missing_data = "missing"
 
   alarm_actions = var.alarm_actions
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
@@ -87,5 +91,9 @@ resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
   treat_missing_data = "notBreaching"
 
   alarm_actions = var.alarm_actions
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 


### PR DESCRIPTION
Since the name/description of the `aws_cloudwatch_metric_alarm` resources in this module is limited to just the environment name, this makes the module unable to create more than one set of alarms (i.e. for more than one Load Balancer in a single environment).

As a result, calling this module multiple times within a given moduleset will cause it to overwrite itself, e.g.:

Terraform plan:
```
 # module.idp_alb_http_alerts.aws_cloudwatch_metric_alarm.elb_http_5xx will be updated in-place
 ~ resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
   ~ dimensions = {
     ~ "LoadBalancer" = "login-app-elb-ENV" -> "arn:aws:elasticloadbalancing:us-west-2:111122223333:loadbalancer/app/login-idp-alb-ENV/0123456789abcdef"

 # module.idp_alb_http_alerts.aws_cloudwatch_metric_alarm.target_http_5xx will be updated in-place
 ~ resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
   ~ dimensions = {
     ~ "LoadBalancer" = "login-app-elb-ENV" -> "arn:aws:elasticloadbalancing:us-west-2:111122223333:loadbalancer/app/login-idp-alb-ENV/0123456789abcdef"
```

After `apply`ing, Terraform thinks the resource has been updated:
```
$ terraform state show module.idp_alb_http_alerts.aws_cloudwatch_metric_alarm.elb_http_5xx
...
    alarm_name                = "ENV IDP ELB HTTP 5XX"
    arn                       = "arn:aws:cloudwatch:us-west-2:111122223333:alarm:ENV IDP ELB HTTP 5XX"
    dimensions                = {
        "LoadBalancer" = "arn:aws:elasticloadbalancing:us-west-2:111122223333:loadbalancer/app/login-idp-alb-ENV/0123456789abcdef"
    }
...
```

But in actuality:
```
aws cloudwatch describe-alarms --alarm-names 'ENV IDP ELB HTTP 5XX' --query 'MetricAlarms[].Dimensions'
[
    [
        {
            "Name": "LoadBalancer",
            "Value": "login-app-elb-ENV"
        }
    ]
]
```

This refactors the module so that the alarms and descriptions are specific to the type/name/environment for the Load Balancer (either by passing a name manually or by calculating from the environment name and ELB type), and the namespace and metric names are correct for either type of Load Balancer (i.e. `HTTPCode_ELB_5XX_Count` for ALB vs `HTTPCode_ELB_5XX` for Classic ELB, etc.) -- allowing it to be used, well, modularly.