### PR TITLE
update modules to support AWS Provider v4.x

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -51,8 +51,8 @@ resource "aws_s3_bucket" "logs" {
   }
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {
-  bucket = aws_s3_bucket.cloudtrail.bucket
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
 
   rule {
     apply_server_side_encryption_by_default {

--- a/git2s3_artifacts/outputs.tf
+++ b/git2s3_artifacts/outputs.tf
@@ -1,3 +1,3 @@
 output "output_bucket" {
-  value = aws_s3_bucket_object.git2s3_output_bucket_name.key
+  value = aws_s3_object.git2s3_output_bucket_name.key
 }

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -584,8 +584,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 
   lifecycle {
     ignore_changes = [
-      s3_key,
-      last_modified,
+      s3_key
     ]
   }
 
@@ -773,8 +772,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 
   lifecycle {
     ignore_changes = [
-      s3_key,
-      last_modified,
+      s3_key
     ]
   }
 
@@ -916,8 +914,7 @@ resource "aws_lambda_function" "event_processor" {
 
   lifecycle {
     ignore_changes = [
-      s3_key,
-      last_modified,
+      s3_key
     ]
   }
 

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -30,6 +30,7 @@ resource "aws_launch_template" "template" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = var.metadata_response_hop_limit
+    instance_metadata_tags      = "enabled"
   }
 
   monitoring {

--- a/launch_template/main.tf
+++ b/launch_template/main.tf
@@ -30,7 +30,6 @@ resource "aws_launch_template" "template" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = var.metadata_response_hop_limit
-    instance_metadata_tags      = "enabled"
   }
 
   monitoring {

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -95,7 +95,7 @@ resource "aws_s3_bucket_logging" "ssm_logs" {
 }
 
 resource "aws_s3_bucket_versioning" "ssm_logs" {
-  bucket = aws_s3_bucket.ssm_logs.bucket
+  bucket = aws_s3_bucket.ssm_logs.id
 
   versioning_configuration {
     status = "Enabled"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
     status = "Enabled"
 
     filter {
-      prefix  = "/"
+      prefix = "/"
     }
 
     transition {
@@ -128,7 +128,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
       days = 2190
     }
     noncurrent_version_expiration {
-      days = 2190
+      noncurrent_days = 2190
     }
   }
 }

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -95,7 +95,7 @@ resource "aws_s3_bucket_versioning" "s3-logs" {
   bucket = aws_s3_bucket.s3-logs.id
 
   versioning_configuration {
-    status = "Disabled"
+    status = "Suspended"
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -22,5 +22,5 @@ terraform {
       source = "newrelic/newrelic"
     }
   }
-  required_version = ">= 1.1.3"
+  required_version = ">= 1.2.4"
 }


### PR DESCRIPTION
This primarily consists of updates to the `aws_s3_bucket` resource family. As of `v4.x` of the AWS Provider for Terraform, the various major attributes for the `aws_s3_bucket` resource have all been split out into individual resource types, e.g.:

- `aws_s3_bucket_server_side_encryption_configuration`
- `aws_s3_bucket_acl`
- `aws_s3_bucket_versioning`
- etc.

This PR breaks out those resources, as the aforementioned attributes for `aws_s3_bucket` resources are now deprecated. It also adds `instance_metadata_tags = "enabled"` to the `launch_template` module (ensuring that instances can access their tag metadata), updates some dependency/`count` blocks, and moves bucket logging to the `s3-access-logs` bucket (from `s3-logs`) as the latter has been deprecated within our own configurations.