### PR TITLE
updated state_bucket module with support for AWSv4 S3 resources

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -181,7 +181,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -122,7 +122,7 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -613,7 +613,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -800,7 +800,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source   = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source   = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source = "github.com/18F/identity-terraform//null_archive?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   source_code_filename = "slack_lambda.py"
   source_dir           = "${path.module}/src/"

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source = "github.com/18F/identity-terraform//null_archive?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   source_code_filename = "windowed_slo.py"
   source_dir           = "${path.module}/src/"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -134,7 +134,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"

--- a/state_bucket/README.md
+++ b/state_bucket/README.md
@@ -1,14 +1,45 @@
 # `state_bucket`
 
-This module manages the terraform remote state S3 bucket and remote state
-DynamoDB lock table. These are tricky resources to manage because there is a
-chicken and egg bootstrapping problem involved in creating them. Terraform
-needs the remote state bucket to exist before it runs for the first time. But
-we also do want to manage this bucket in terraform so that it doesn't diverge
-from the expected configuration (encryption, versioning, etc.).
+This module creates and manages S3 buckets for AWS S3 Inventory (storage/configration) and S3 Logging, and (optionally) the Terraform remote state S3 bucket and remote state DynamoDB lock table.
 
-For bootstrapping, the remote state bucket will be automatically created by
-`bin/tf-deploy` using `bin/configure_state_bucket.sh`. Then, import those
-resources into terraform for management by running the `terraform import`
-commands found in comments in [./main.tf](./main.tf).
+## Example
 
+```hcl
+module "tf-state" {
+  source = "github.com/18F/identity-terraform//state_bucket?ref=main"
+
+  remote_state_enabled = 1
+  region               = var.region
+  bucket_name_prefix   = var.bucket_name_prefix
+  sse_algorithm        = "AES256"
+}
+```
+
+## Managing Remote State Configs From Within Terraform
+
+***NOTE:** If choosing not to manage the S3 remote state bucket and DynamoDB lock table within Terraform, set the `remote_state_enabled` variable to **0**. Otherwise, read on!*
+
+Traditionally, these are tricky resources to manage because there is a chicken and egg bootstrapping problem involved in creating them: Terraform needs the remote state bucket to exist before it runs for the first time, but we do want to manage this bucket _in_ Terraform so that it doesn't diverge from the expected configuration (encryption, versioning, etc.).
+
+Since version `4.x` of the AWS provider plugin, all of the attributes for an S3 bucket (aside from its name and its `prevent_destroy` lifecycle configuration) are configured within independent resources. As a result, Terraform can manage all of these attributes separately -- including adding and removing them, as required -- using the S3 bucket as a _data source_ instead of a directly-managed resource. (The DynamoDB table will still need to be imported into state after creation.)
+
+One possible way to do this, as it pertains to this module, is to create a script which will:
+
+1. create the `tf-state` S3 bucket and `terraform_locks` DynamoDB table manually, i.e. with `aws-cli` operations / SDK API calls
+2. set up a workspace using `terraform init` / `get`
+3. run `import` to add the DynamoDB table to the remote state, e.g.:
+  ```
+  terraform import 'module.main.module.tf-state.aws_dynamodb_table.tf-lock-table[0]' 'terraform_locks'
+  ```
+
+Assuming that the names for the bucket and table match what the module thinks they should be (based on the `bucket_name_prefix` and `state_lock_table` variables), a subsequent `apply` operation should set the DynamoDB table in lockstep with the remote state, and should create the various S3 configuration resources associated with the `tf-state` bucket.
+
+If desiring to _remove_ these resources (e.g. when doing a complete infrastructure teardown), the simplest method would be to remove the entire module (or at least the `s3-access-logs` and `tf-lock-table` resources) from state, run a `destroy` operation, and then delete the remaining resources from AWS manually.
+
+## Variables
+
+`bucket_name_prefix` - First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`
+`region` - AWS Region.
+`remote_state_enabled` - Whether to manage the remote state bucket and DynamoDB lock table (1 for true, 0 for false).
+`state_lock_table` - Name of the DynamoDB table to use for state locking with the S3 state backend, e.g. `terraform_locks`
+`sse_algorithm` - SSE algorithm to use to encrypt reports in S3 Inventory bucket.

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -67,59 +67,6 @@ locals {
 
 # -- Resources --
 
-######## Deprecated bucket ! Delete these blocks ########
-resource "aws_s3_bucket" "s3-logs" {
-  bucket = "${var.bucket_name_prefix}.s3-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
-
-  lifecycle {
-    prevent_destroy = false
-  }
-}
-
-resource "aws_s3_bucket_acl" "s3-logs" {
-  bucket = aws_s3_bucket.s3-logs.id
-  acl    = "log-delivery-write"
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "s3-logs" {
-  bucket = aws_s3_bucket.s3-logs.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
-    }
-  }
-}
-
-resource "aws_s3_bucket_versioning" "s3-logs" {
-  bucket = aws_s3_bucket.s3-logs.id
-
-  versioning_configuration {
-    status = "Suspended"
-  }
-}
-
-resource "aws_s3_bucket_lifecycle_configuration" "s3-logs" {
-  bucket = aws_s3_bucket.s3-logs.id
-
-  rule {
-    id     = "expirelogs"
-    status = "Enabled"
-
-    filter {
-      prefix = "/"
-    }
-
-    expiration {
-      days = 1
-    }
-    noncurrent_version_expiration {
-      noncurrent_days = 1
-    }
-  }
-}
-######## Deprecated bucket ! Delete these blocks ########
-
 # Bucket used for storing S3 access logs
 # do not enable logging on this bucket
 resource "aws_s3_bucket" "s3-access-logs" {

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -1,4 +1,13 @@
+# -- Locals --
+
+locals {
+  log_bucket       = "${var.bucket_name_prefix}.s3-access-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
+  state_bucket     = "${var.bucket_name_prefix}.tf-state.${data.aws_caller_identity.current.account_id}-${var.region}"
+  inventory_bucket = "${var.bucket_name_prefix}.s3-inventory.${data.aws_caller_identity.current.account_id}-${var.region}"
+}
+
 # -- Variables --
+
 variable "bucket_name_prefix" {
   description = "First substring in S3 bucket name of $bucket_name_prefix.$bucket_name.$account_id-$region"
   type        = string
@@ -10,8 +19,8 @@ variable "region" {
 
 variable "remote_state_enabled" {
   description = <<EOM
-Whether to manage the TF remote state bucket and lock table.
-Set this to false if you want to skip this for bootstrapping.
+Whether to manage the remote state bucket
+and DynamoDB lock table (1 for true, 0 for false).
 EOM
   default     = 1
 }
@@ -28,6 +37,7 @@ variable "sse_algorithm" {
 }
 
 # -- Data Sources --
+
 data "aws_caller_identity" "current" {
 }
 
@@ -55,14 +65,6 @@ data "aws_iam_policy_document" "inventory_bucket_policy" {
       values   = ["bucket-owner-full-control"]
     }
   }
-}
-
-# -- Locals --
-
-locals {
-  log_bucket       = "${var.bucket_name_prefix}.s3-access-logs.${data.aws_caller_identity.current.account_id}-${var.region}"
-  state_bucket     = "${var.bucket_name_prefix}.tf-state.${data.aws_caller_identity.current.account_id}-${var.region}"
-  inventory_bucket = "${var.bucket_name_prefix}.s3-inventory.${data.aws_caller_identity.current.account_id}-${var.region}"
 }
 
 # -- Resources --
@@ -245,9 +247,6 @@ resource "aws_dynamodb_table" "tf-lock-table" {
 }
 
 # -- Outputs --
-output "s3_log_bucket" {
-  value = aws_s3_bucket.s3-logs.id
-}
 
 output "s3_access_log_bucket" {
   value = aws_s3_bucket.s3-access-logs.id

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -215,7 +215,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=682105726e7212eaf58cc1a9b1d2ed6ee3a7b6e0"
+  source     = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix


### PR DESCRIPTION
While updating S3 resources/this repo's modules to AWS Provider v4 syntax was mostly a lengthy/toilsome process, we _do_ now have the ability to manage all of the resources for an S3 bucket -- whether or not Terraform creates the bucket itself. This helps to solve half of the chicken-and-egg problem of "how do we manage Terraform remote state resources _in Terraform itself_"; the bucket's ACLs/policy/versioning/inventory/logging config/etc. can all be managed separately after the bucket is created in the first place.

This also cleans up some formatting and updates the `README.md` for the module, which was out of date/using old formatting/references, and adds in some possible ways to deal with creating and importing these resources in Terraform state as seamlessly as possible.