### PR TITLE
add prevent_destroy=true to optionally-created dnssec_disable_prevent policy

### DIFF
--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -117,7 +117,7 @@ resource "aws_kms_key" "dnssec" {
   # 
   # See the README for more info, as well as:
   # https://github.com/hashicorp/terraform/issues/3116
-  # https://github.com/hashicorp/terraform/issues/4149
+  # https://github.com/hashicorp/terraform/issues/30937
 
   #lifecycle {
   #  prevent_destroy = true
@@ -218,6 +218,12 @@ resource "aws_iam_policy" "dnssec_disable_prevent" {
   path        = "/"
   description = "Prevent disabling of DNSSEC / deletion of hosted zone ${var.dnssec_zone_name}"
   policy      = data.aws_iam_policy_document.dnssec_disable_prevent[count.index].json
+
+  # extra safeguard while the KMS/DNSSEC resources can't conditionally
+  # have their own lifecycle rules set, as discussed above
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "dnssec" {


### PR DESCRIPTION
[Lifecycle rules *still* (as of 2022-08-11) do not yet support interpolation](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#literal-values-only), so we still can't conditionally set `prevent_destroy = true` for the DNSSEC signing/KMS/KSK resources.

However, since we ***are*** using `var.protect_resources` to conditionally create the `DNSSecDisablePrevent` IAM policy, we can add `prevent_destroy = true` to *that* as an additional way to guard against an accidental mass-`terraform destroy` operation against DNSSEC resources.

This PR adds that lifecycle rule, and updates the comments and `README` accordingly (along with including a link to [a new official Terraform issue](https://github.com/hashicorp/terraform/issues/30937), where discussion about said concepts is still ongoing).