### PR TITLE
Add iam output to iamassumerole

### DIFF
--- a/iam_assumerole/main.tf
+++ b/iam_assumerole/main.tf
@@ -82,3 +82,7 @@ resource "aws_iam_role_policy_attachment" "policy_attachment_custom" {
   role       = aws_iam_role.iam_assumable_role[0].name
   policy_arn = element(var.custom_policy_arns, count.index)
 }
+
+output "iam_assumable_role" {
+  value = aws_iam_role.iam_assumable_role
+}


### PR DESCRIPTION
Addresses part of  [#5014](https://github.com/18F/identity-devops/issues/5014).  Adding support for conditions in iam policy documents:

- Adds output for iam_role
- Adds new optional `conditions` property in the `policy_document`
- Adds dynamic condition to add conditions to policies