### PR TITLE
Add slash to target_prefix

### DIFF
--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -118,7 +118,7 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
   bucket = aws_s3_bucket.artifact_bucket.id
 
   target_bucket = local.log_bucket
-  target_prefix = "${var.bucket_name_prefix}-public-artifacts-${var.region}"
+  target_prefix = "${var.bucket_name_prefix}-public-artifacts-${var.region}/"
 }
 
 module "s3_config" {


### PR DESCRIPTION
Adds a '/' at the end of `target_prefix`, so all of the log files for 'public-artifacts' will go into their own folder instead of the root of the s3 bucket.