### PR TITLE
support multiple/complex expressions/schedule combinations in asg_recycle module

### DIFF
--- a/asg_recycle/README.md
+++ b/asg_recycle/README.md
@@ -34,9 +34,7 @@ The `cron` expressions for the predefined schedules are as follows:
 | `weeklyzero_normal`     | <pre>0 11,17,23 * * 1<br>0 5,11,17,23 * * 2-4<br>0 5,11 * * 5</pre> | <pre>15 11,17,23 * * 1<br>15 5,11,17,23 * * 2-4<br>15 5,11 * * 5</pre> | `0 5 * * 1`          | `0 17 * * 5`           |
 | `weeklyzero_business`   | `0 17 * * 1-4`                                                      | `15 17 * * 1-4`                                                        | `0 5 * * 1`          | `0 17 * * 5`           |
 
-To use one of these, set the `scale_schedule` variable to the name of the desired schedule, and the module will extract its corresponding 'recycle'/'zero out' schedules from the `local.rotation_schedules` map in `schedule.tf`.
-
-If desiring to use a different set of expressions for 'recycle' and/or 'zero out' schedules, the `custom_schedule` map variable can be used instead, e.g.:
+If desiring to use a different set of expressions for 'recycle' and/or 'zero out' schedules, `var.custom_schedule` can be used instead, e.g.:
 
 ```terraform
 custom_schedule = {
@@ -48,6 +46,8 @@ custom_schedule = {
   }
 }
 ```
+
+To use a set of expressions, set `var.scale_schedule` to the name of the desired schedule, and the module will extract its corresponding 'recycle'/'zero out' schedules from the `local.rotation_schedules` map in `schedule.tf` (or `var.custom_schedule`, if using that instead).
 
 ## Examples
 
@@ -74,6 +74,7 @@ module "migration_recycle" {
   time_zone                  = "America/New_York"
   spinup_mult_factor         = 1
   override_spindown_capacity = 0
+  scale_schedule             = "migration_nightlyzero_business"
   custom_schedule = {
     "migration_nightlyzero_business" = {
       recycle_up   = ["50 16 * * 1-5"]
@@ -90,14 +91,14 @@ module "migration_recycle" {
 
 ## Variables
 
-| Name                         | Type                     | Description                                                                                                                           | Required | Default            |
-| ----                         | ----                     | -----------                                                                                                                           | -------- | -------            |
-| `asg_name`                   | string                   | Name of the Auto Scaling Group to apply scheduled actions to                                                                          | YES      | N/A                |
-| `normal_desired_capacity`    | number                   | Default Desired capacity for the Auto Scaling Group                                                                                   | YES      | N/A                |
-| `override_spindown_capacity` | number                   | Set a specific number of instances for spindown instead of `normal_desired_capacity`                                                  | NO       | -1                 |
-| `max_size`                   | number                   | Default maximum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
-| `min_size`                   | number                   | Default minimum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
-| `spinup_mult_factor`         | number                   | Multiplier for `normal_desired_capacity` to calculate Desired capacity (normal x mult) for the `auto-recycle.spinup` scheduled action | NO       | 2                  |
-| `time_zone`                  | string                   | IANA time zone to use with cron schedules (uses UTC by default)                                                                       | NO       | Etc/UTC            |
-| `scale_schedule`             | string                   | Name of one of the blocks in schedule.tf which defines the cron schedules for 'recycle' and/or 'zero out' Scheduled Actions           | NO       | `nozero_norecycle` |
-| `custom_schedule`            | map(`map(list(string))`) | Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts (overrides `scale_schedule` if set)                      | NO       | {}                 |
+| Name                         | Type    | Description                                                                                                                           | Required | Default            |
+| ----                         | ----    | -----------                                                                                                                           | -------- | -------            |
+| `asg_name`                   | string  | Name of the Auto Scaling Group to apply scheduled actions to                                                                          | YES      | N/A                |
+| `normal_desired_capacity`    | number  | Default Desired capacity for the Auto Scaling Group                                                                                   | YES      | N/A                |
+| `override_spindown_capacity` | number  | Set a specific number of instances for spindown instead of `normal_desired_capacity`                                                  | NO       | -1                 |
+| `max_size`                   | number  | Default maximum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
+| `min_size`                   | number  | Default minimum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
+| `spinup_mult_factor`         | number  | Multiplier for `normal_desired_capacity` to calculate Desired capacity (normal x mult) for the `auto-recycle.spinup` scheduled action | NO       | 2                  |
+| `time_zone`                  | string  | IANA time zone to use with cron schedules (uses UTC by default)                                                                       | NO       | Etc/UTC            |
+| `scale_schedule`             | string  | Name of a block in `local.rotation_schedules` or `var.custom_schedule` with `cron` schedules for the associated Scheduled Actions     | NO       | `nozero_norecycle` |
+| `custom_schedule`            | `any`   | Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts (overrides `local.rotation_schedules` if set)            | NO       | {}                 |

--- a/asg_recycle/README.md
+++ b/asg_recycle/README.md
@@ -1,10 +1,103 @@
-# ASG Recycle
+# `asg_recycle`
 
-This module creates scheduled actions to change the desired count of an auto
-scaling group. It is designed to provide for an automatic recycle of all
-instances in the ASG by doubling the number of instances and then returning to
-the original desired count. This works on ASGs that use an OldestInstance
-termination policy.
+This Terraform module is used to create automatic tasks that 'recycle' and/or 'zero out' the EC2 instances in an Auto Scaling Group (ASG), via a set of Scheduled Actions applied to the group. These tasks are defined thusly:
 
-It supports two default modes: a once/6hr recycle (default) or a once/business
-day recycle. You can also pass through arbitrary cron expressions.
+- ***Recycling*** involves doubling the Desired count of an ASG, allowing new instances to spin up, and then resetting the Desired count back to its original value after a specific number of minutes.
+- ***Zeroing out*** involves setting the Desired count of an ASG to 0 at a specified time, which is useful for spinning down hosts on a daily/nightly/weekly/etc. basis when they will not be in use.
+
+Since the goal of these Scheduled Actions is to replace older EC2 instances with newer ones, this module *only* works on ASGs that use an `OldestInstance` termination policy.
+
+## Schedules
+
+Within `schedule.tf` is a local variable, `rotation_schedules`, which is a map of predefined schedules for recycling and/or zeroing out hosts, based on common scaling needs for ASGs:
+
+- `*zero` schedules define how frequently (if at all) 'zero out' actions are run; the actions they create will spin up instances at 0500 and spin them down to 0 at 1600
+- `norecycle` schedules do not create 'recycle' actions, regardless of whether or not 'zero out' actions are also created
+- `normal` schedules create 4 'recycle' actions every day (at 0500 / 1100 / 1700 / 2300)
+- `business` schedules create a single 'recycle' action each weekday (at 1700)
+- For schedules that call for both types of actions, any times normally used by the 'recycle' schedule are instead used by the 'zero out' schedule (in order to prevent overlapping/duplicate Scheduled Actions)
+
+The `cron` expressions for the predefined schedules are as follows:
+
+| Schedule Name           | Recycle UP Schedule                                                 | Recycle DOWN Schedule                                                  | Zero-Out UP Schedule | Zero-Out DOWN Schedule |
+| ----------              | ----------                                                          | ----------                                                             | ----------           | ----------             |
+| `nozero_norecycle`      | N/A                                                                 | N/A                                                                    | N/A                  | N/A                    |
+| `nozero_normal`         | `0 5,11,17,23 * * *`                                                | `15 5,11,17,23 * * *`                                                  | N/A                  | N/A                    |
+| `nozero_business`       | `0 17 * * 1-5`                                                      | `15 17 * * 1-5`                                                        | N/A                  | N/A                    |
+| `dailyzero_norecycle`   | N/A                                                                 | N/A                                                                    | `0 5 * * 1-5`        | `0 17 * * 1-5`         |
+| `dailyzero_normal`      | `0 11 * * 1-5`                                                      | `15 11 * * 1-5`                                                        | `0 5 * * 1-5`        | `0 17 * * 1-5`         |
+| `dailyzero_business`    | N/A                                                                 | N/A                                                                    | `0 5 * * 1-5`        | `0 17 * * 1-5`         |
+| `nightlyzero_norecycle` | N/A                                                                 | N/A                                                                    | `0 5 * * 1-5`        | `0 21 * * 1-5`         |
+| `nightlyzero_normal`    | `0 11,17 * * 1-5`                                                   | `15 11,17 * * 1-5`                                                     | `0 5 * * 1-5`        | `0 21 * * 1-5`         |
+| `nightlyzero_business`  | `0 17 * * 1-5`                                                      | `15 17 * * 1-5`                                                        | `0 5 * * 1-5`        | `0 21 * * 1-5`         |
+| `weeklyzero_norecycle`  | N/A                                                                 | N/A                                                                    | `0 5 * * 1`          | `0 17 * * 5`           |
+| `weeklyzero_normal`     | <pre>0 11,17,23 * * 1<br>0 5,11,17,23 * * 2-4<br>0 5,11 * * 5</pre> | <pre>15 11,17,23 * * 1<br>15 5,11,17,23 * * 2-4<br>15 5,11 * * 5</pre> | `0 5 * * 1`          | `0 17 * * 5`           |
+| `weeklyzero_business`   | `0 17 * * 1-4`                                                      | `15 17 * * 1-4`                                                        | `0 5 * * 1`          | `0 17 * * 5`           |
+
+To use one of these, set the `scale_schedule` variable to the name of the desired schedule, and the module will extract its corresponding 'recycle'/'zero out' schedules from the `local.rotation_schedules` map in `schedule.tf`.
+
+If desiring to use a different set of expressions for 'recycle' and/or 'zero out' schedules, the `custom_schedule` map variable can be used instead, e.g.:
+
+```terraform
+custom_schedule = {
+  "asg_rotation_schedule" = {
+    recycle_up    = ["0 11 * * 1-5"]
+    recycle_down  = ["15 11 * * 1-5"]
+    autozero_up   = ["0 5 * * 1-5"]
+    autozero_down = ["0 17 * * 1-5"]
+  }
+}
+```
+
+## Examples
+
+Using one of the schedules from `local.rotation_schedules` / `schedules.tf`:
+
+```terraform
+module "idp_recycle" {
+  source = "github.com/18F/identity-terraform//asg_recycle?ref=main"
+
+  asg_name                = aws_autoscaling_group.idp.name
+  normal_desired_capacity = aws_autoscaling_group.idp.desired_capacity
+  scale_schedule          = "nightlyzero_business"
+}
+```
+
+Using `var.custom_schedule` and overrides for the multiplier, timezone, and spindown capacity:
+
+```terraform
+module "migration_recycle" {
+  source = "github.com/18F/identity-terraform//asg_recycle?ref=main"
+
+  asg_name                   = aws_autoscaling_group.migration.name
+  normal_desired_capacity    = 1
+  time_zone                  = "America/New_York"
+  spinup_mult_factor         = 1
+  override_spindown_capacity = 0
+  custom_schedule = {
+    "migration_nightlyzero_business" = {
+      recycle_up   = ["50 16 * * 1-5"]
+      recycle_down = ["20 17 * * 1-5"]
+      autozero_up  = ["50 4 * * *"]
+      autozero_down = [
+        "20 5 * * *",
+        "50 20 * * *"
+      ]
+    }
+  }
+}
+```
+
+## Variables
+
+| Name                         | Type                     | Description                                                                                                                           | Required | Default            |
+| ----                         | ----                     | -----------                                                                                                                           | -------- | -------            |
+| `asg_name`                   | string                   | Name of the Auto Scaling Group to apply scheduled actions to                                                                          | YES      | N/A                |
+| `normal_desired_capacity`    | number                   | Default Desired capacity for the Auto Scaling Group                                                                                   | YES      | N/A                |
+| `override_spindown_capacity` | number                   | Set a specific number of instances for spindown instead of `normal_desired_capacity`                                                  | NO       | -1                 |
+| `max_size`                   | number                   | Default maximum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
+| `min_size`                   | number                   | Default minimum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
+| `spinup_mult_factor`         | number                   | Multiplier for `normal_desired_capacity` to calculate Desired capacity (normal x mult) for the `auto-recycle.spinup` scheduled action | NO       | 2                  |
+| `time_zone`                  | string                   | IANA time zone to use with cron schedules (uses UTC by default)                                                                       | NO       | Etc/UTC            |
+| `scale_schedule`             | string                   | Name of one of the blocks in schedule.tf which defines the cron schedules for 'recycle' and/or 'zero out' Scheduled Actions           | NO       | `nozero_norecycle` |
+| `custom_schedule`            | map(`map(list(string))`) | Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts (overrides `scale_schedule` if set)                      | NO       | {}                 |

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -1,102 +1,60 @@
-# Remove this variable when modules support count
-# https://github.com/hashicorp/terraform/issues/953
-variable "enabled" {
-  default     = 1
-  description = "Whether this module is enabled (hack around modules not supporting count)"
-}
-
-variable "asg_name" {
-  description = "Name of the auto scaling group to recycle"
-}
-
-variable "normal_desired_capacity" {
-  description = ""
-}
-
-variable "override_spindown_capacity" {
-  description = "Set a specific number of instances for spindown instead of normal_desired_capacity"
-  default     = -1
-}
-
-variable "max_size" {
-  default = -1
-}
-
-variable "min_size" {
-  default = -1
-}
-
-variable "spinup_mult_factor" {
-  default     = 2
-  description = "Multiple of normal_desired_capacity to spin up"
-}
-
-variable "spinup_recurrence" {
-  default     = ""
-  description = "Spinup times in cron format, sets aws_autoscaling_schedule.spinup.recurrence"
-}
-
-variable "spindown_recurrence" {
-  default     = ""
-  description = "Spindown times in cron format, sets aws_autoscaling_schedule.spindown.recurrence"
-}
-
-variable "use_daily_business_hours_schedule" {
-  default     = 0
-  description = "If set to 1, recycle once per business day rather than the every-six-hour default"
-}
-
-# This block defines the actual default spinup/spindown schedule.
-# If use_daily_business_hours_schedule is enabled, from Mon-Fri spin up at 1700
-# UTC and spin down at 1730 UTC. Otherwise recycle every 6 hours every day by default.
 locals {
-  default_spinup_recurrence   = var.use_daily_business_hours_schedule == 1 ? "0 17 * * 1-5" : "0 5,11,17,23 * * *"
-  default_spindown_recurrence = var.use_daily_business_hours_schedule == 1 ? "30 17 * * 1-5" : "30 5,11,17,23 * * *"
+  schedule = (
+    var.custom_schedule == {} ? lookup(
+      local.rotation_schedules, var.scale_schedule
+    ) : var.custom_schedule
+  )
 }
 
-# Default schedule unless spinup_recurrence / spindown_recurrence are overridden:
-# Spin up happens at   0500, 1100, 1700, 2300 UTC.
-# Spin down happens at 0600, 1200, 1800, 0000 UTC.
-#
-# If IdP bootstrapping were faster (i.e. we reduce the ALB health check grace
-# period time), we can reduce the interval between spinup and spindown.
-
-# EST times (UTC-5):
-# Spin up at   12a, 6a, 12p, 6p EST
-# Spin down at  1a, 7a,  1p, 7p EST
-
-# EDT times (UTC-4):
-# Spin up at   1a, 7a, 1p, 7p EDT
-# Spin down at 2a, 8a, 2p, 8p EDT
-
-# PST times (UTC-8):
-# Spin up at   3a, 9a,  3p, 9p  PST
-# Spin down at 4a, 10a, 4p, 10p PST
-
-# PDT times (UTC-7):
-# Spin up at   4a, 10a, 4p, 10p PDT
-# Spin down at 5a, 11a, 5p, 11p PDT
-
-resource "aws_autoscaling_schedule" "spinup" {
-  count = var.enabled
+resource "aws_autoscaling_schedule" "recycle_spinup" {
+  for_each = toset(local.schedule["recycle_up"])
 
   scheduled_action_name  = "auto-recycle.spinup"
   min_size               = var.min_size
   max_size               = var.max_size
   desired_capacity       = var.normal_desired_capacity * var.spinup_mult_factor
-  recurrence             = var.spinup_recurrence != "" ? var.spinup_recurrence : local.default_spinup_recurrence
+  recurrence             = each.key
+  time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
 }
 
-resource "aws_autoscaling_schedule" "spindown" {
-  count = var.enabled
+resource "aws_autoscaling_schedule" "recycle_spindown" {
+  for_each = toset(local.schedule["recycle_down"])
 
   scheduled_action_name = "auto-recycle.spindown"
   min_size              = var.min_size
   max_size              = var.max_size
-  desired_capacity      = var.override_spindown_capacity == -1 ? var.normal_desired_capacity : var.override_spindown_capacity
-  recurrence            = var.spindown_recurrence != "" ? var.spindown_recurrence : local.default_spindown_recurrence
-
+  desired_capacity = var.override_spindown_capacity == -1 ? (
+  var.normal_desired_capacity) : var.override_spindown_capacity
+  recurrence             = each.key
+  time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
 }
 
+# Spin down to 0 hosts, on a regular schedule. Depending upon selection,
+# do this either daily after working hours, weekly (same time), or nightly.
+# Follow a similar schedule to the recycle one above.
+
+resource "aws_autoscaling_schedule" "autozero_spinup" {
+  for_each = toset(local.schedule["autozero_up"])
+
+  scheduled_action_name  = "auto-zero.spinup"
+  min_size               = var.min_size
+  max_size               = var.max_size
+  desired_capacity       = var.normal_desired_capacity
+  recurrence             = each.key
+  time_zone              = var.time_zone
+  autoscaling_group_name = var.asg_name
+}
+
+resource "aws_autoscaling_schedule" "autozero_spindown" {
+  for_each = toset(local.schedule["autozero_down"])
+
+  scheduled_action_name  = "auto-zero.spindown"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  recurrence             = each.key
+  time_zone              = var.time_zone
+  autoscaling_group_name = var.asg_name
+}

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -1,8 +1,8 @@
 locals {
-  schedule = (
-    var.custom_schedule == {} ? lookup(
-      local.rotation_schedules, var.scale_schedule
-    ) : var.custom_schedule
+  schedule_map = var.custom_schedule == {} ? local.rotation_schedules : var.custom_schedule
+  schedule = lookup(
+    { for k, v in local.schedule_map : k => v if k == var.scale_schedule },
+    var.scale_schedule
   )
 }
 

--- a/asg_recycle/schedule.tf
+++ b/asg_recycle/schedule.tf
@@ -1,0 +1,84 @@
+locals {
+  rotation_schedules = {
+    "nozero_norecycle" = {
+      recycle_up    = []
+      recycle_down  = []
+      autozero_up   = []
+      autozero_down = []
+    }
+    "nozero_normal" = {
+      recycle_up    = ["0 5,11,17,23 * * *"]
+      recycle_down  = ["15 5,11,17,23 * * *"]
+      autozero_up   = []
+      autozero_down = []
+    }
+    "nozero_business" = {
+      recycle_up    = ["0 17 * * 1-5"]
+      recycle_down  = ["15 17 * * 1-5"]
+      autozero_up   = []
+      autozero_down = []
+    }
+    "dailyzero_norecycle" = {
+      recycle_up    = []
+      recycle_down  = []
+      autozero_up   = ["0 5 * * 1-5"]
+      autozero_down = ["0 17 * * 1-5"]
+    }
+    "dailyzero_normal" = {
+      recycle_up    = ["0 11 * * 1-5"]
+      recycle_down  = ["15 11 * * 1-5"]
+      autozero_up   = ["0 5 * * 1-5"]
+      autozero_down = ["0 17 * * 1-5"]
+    }
+    "dailyzero_business" = {
+      recycle_up    = []
+      recycle_down  = []
+      autozero_up   = ["0 5 * * 1-5"]
+      autozero_down = ["0 17 * * 1-5"]
+    }
+    "nightlyzero_norecycle" = {
+      recycle_up    = []
+      recycle_down  = []
+      autozero_up   = ["0 5 * * 1-5"]
+      autozero_down = ["0 21 * * 1-5"]
+    }
+    "nightlyzero_normal" = {
+      recycle_up    = ["0 11,17 * * 1-5"]
+      recycle_down  = ["15 11,17 * * 1-5"]
+      autozero_up   = ["0 5 * * 1-5"]
+      autozero_down = ["0 21 * * 1-5"]
+    }
+    "nightlyzero_business" = {
+      recycle_up    = ["0 17 * * 1-5"]
+      recycle_down  = ["15 17 * * 1-5"]
+      autozero_up   = ["0 5 * * 1-5"]
+      autozero_down = ["0 21 * * 1-5"]
+    }
+    "weeklyzero_norecycle" = {
+      recycle_up    = []
+      recycle_down  = []
+      autozero_up   = ["0 5 * * 1"]
+      autozero_down = ["0 17 * * 5"]
+    }
+    "weeklyzero_normal" = {
+      recycle_up = [
+        "0 11,17,23 * * 1",
+        "0 5,11,17,23 * * 2-4",
+        "0 5,11 * * 5",
+      ]
+      recycle_down = [
+        "15 11,17,23 * * 1",
+        "15 5,11,17,23 * * 2-4",
+        "15 5,11 * * 5",
+      ]
+      autozero_up   = ["0 5 * * 1"]
+      autozero_down = ["0 17 * * 5"]
+    }
+    "weeklyzero_business" = {
+      recycle_up    = ["0 17 * * 1-4"]
+      recycle_down  = ["15 17 * * 1-4"]
+      autozero_up   = ["0 5 * * 1"]
+      autozero_down = ["0 17 * * 5"]
+    }
+  }
+}

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -52,7 +52,7 @@ variable "scale_schedule" {
   description = <<EOM
 Name of one of the blocks defined in schedule.tf, which defines the cron schedules
 for recycling and/or 'autozero' scheduled actions. MUST match one of the key names
-in local.rotation_schedules. Ignored if var.custom_schedule has been set.
+in local.rotation_schedules (or var.custom_schedule if using that instead).
 EOM
   type        = string
   default     = "nozero_norecycle"
@@ -61,7 +61,7 @@ EOM
 variable "custom_schedule" {
   description = <<EOM
 Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts.
-If set, var.scale_schedule will be ignored in favor of whatever is defined here.
+MUST contain at least one object with var.scale_schedule as its name, and
 MUST follow the defined format as shown for the default value!
 EOM
   type        = any

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -43,7 +43,7 @@ EOM
 }
 
 variable "time_zone" {
-  description = "IANA time zone to use with cron schedules (uses UTC by default)."
+  description = "IANA time zone to use with cron schedules. Uses UTC by default."
   type        = string
   default     = "Etc/UTC"
 }

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -64,13 +64,13 @@ Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts.
 If set, var.scale_schedule will be ignored in favor of whatever is defined here.
 MUST follow the defined format as shown for the default value!
 EOM
-  type        = map(any)
+  type        = any
   default = {
-    #    "custom_schedule" = {
-    #      recycle_up    = ["0 11 * * 1-5"]
-    #      recycle_down  = ["15 11 * * 1-5"]
-    #      autozero_up   = ["0 5 * * 1-5"]
-    #      autozero_down = ["0 17 * * 1-5"]
-    #    }
+    #   "custom_schedule" = {
+    #     recycle_up    = ["0 11 * * 1-5"]
+    #     recycle_down  = ["15 11 * * 1-5"]
+    #     autozero_up   = ["0 5 * * 1-5"]
+    #     autozero_down = ["0 17 * * 1-5"]
+    #   }
   }
 }

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -64,7 +64,7 @@ Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts.
 If set, var.scale_schedule will be ignored in favor of whatever is defined here.
 MUST follow the defined format as shown for the default value!
 EOM
-  type        = map(map(list(string)))
+  type        = map(any)
   default = {
     #    "custom_schedule" = {
     #      recycle_up    = ["0 11 * * 1-5"]

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -1,0 +1,76 @@
+variable "asg_name" {
+  description = "Name of the Auto Scaling Group to apply scheduled actions to."
+  type        = string
+}
+
+variable "normal_desired_capacity" {
+  description = <<EOM
+Default Desired capacity for the Auto Scaling Group.
+Multiplied by spinup_mult_factor to set the Desired capacity for auto-recycle.spinup.
+Used for auto-recycle.spindown, unless override_spindown_capacity has been set.
+EOM
+  type        = number
+}
+
+variable "override_spindown_capacity" {
+  description = <<EOM
+Set a specific number of instances for spindown instead of normal_desired_capacity.
+Will ONLY override the Desired capacity for the auto-recycle.spindown action.
+EOM
+  type        = number
+  default     = -1
+}
+
+variable "max_size" {
+  description = "Default maximum capacity for the Auto Scaling Group."
+  type        = number
+  default     = -1
+}
+
+variable "min_size" {
+  description = "Default minimum capacity for the Auto Scaling Group."
+  type        = number
+  default     = -1
+}
+
+variable "spinup_mult_factor" {
+  description = <<EOM
+Multiplier for normal_desired_capacity to calculate Desired capacity (normal x mult)
+for the auto-recycle.spinup scheduled action.
+EOM
+  type        = number
+  default     = 2
+}
+
+variable "time_zone" {
+  description = "IANA time zone to use with cron schedules (uses UTC by default)."
+  type        = string
+  default     = "Etc/UTC"
+}
+
+variable "scale_schedule" {
+  description = <<EOM
+Name of one of the blocks defined in schedule.tf, which defines the cron schedules
+for recycling and/or 'autozero' scheduled actions. MUST match one of the key names
+in local.rotation_schedules. Ignored if var.custom_schedule has been set.
+EOM
+  type        = string
+  default     = "nozero_norecycle"
+}
+
+variable "custom_schedule" {
+  description = <<EOM
+Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts.
+If set, var.scale_schedule will be ignored in favor of whatever is defined here.
+MUST follow the defined format as shown for the default value!
+EOM
+  type        = map(map(list(string)))
+  default = {
+    #    "custom_schedule" = {
+    #      recycle_up    = ["0 11 * * 1-5"]
+    #      recycle_down  = ["15 11 * * 1-5"]
+    #      autozero_up   = ["0 5 * * 1-5"]
+    #      autozero_down = ["0 17 * * 1-5"]
+    #    }
+  }
+}


### PR DESCRIPTION
This PR updates the `asg_recycle` module to support a more complex configuration of scaling schedules, allowing one to define custom `cron` expressions for recycling and/or zeroing out hosts in ASGs.

## Schedules

Within `schedule.tf` is a local variable, `rotation_schedules`, which is a map of predefined schedules for recycling and/or zeroing out hosts, based on common scaling needs for ASGs:

- `*zero` schedules define how frequently (if at all) 'zero out' actions are run; the actions they create will spin up instances at 0500 and spin them down to 0 at 1600
- `norecycle` schedules do not create 'recycle' actions, regardless of whether or not 'zero out' actions are also created
- `normal` schedules create 4 'recycle' actions every day (at 0500 / 1100 / 1700 / 2300)
- `business` schedules create a single 'recycle' action each weekday (at 1700)
- For schedules that call for both types of actions, any times normally used by the 'recycle' schedule are instead used by the 'zero out' schedule (in order to prevent overlapping/duplicate Scheduled Actions)

The `cron` expressions for the predefined schedules are as follows:

| Schedule Name           | Recycle UP Schedule                                                 | Recycle DOWN Schedule                                                  | Zero-Out UP Schedule | Zero-Out DOWN Schedule |
| ----------              | ----------                                                          | ----------                                                             | ----------           | ----------             |
| `nozero_norecycle`      | N/A                                                                 | N/A                                                                    | N/A                  | N/A                    |
| `nozero_normal`         | `0 5,11,17,23 * * *`                                                | `15 5,11,17,23 * * *`                                                  | N/A                  | N/A                    |
| `nozero_business`       | `0 17 * * 1-5`                                                      | `15 17 * * 1-5`                                                        | N/A                  | N/A                    |
| `dailyzero_norecycle`   | N/A                                                                 | N/A                                                                    | `0 5 * * 1-5`        | `0 17 * * 1-5`         |
| `dailyzero_normal`      | `0 11 * * 1-5`                                                      | `15 11 * * 1-5`                                                        | `0 5 * * 1-5`        | `0 17 * * 1-5`         |
| `dailyzero_business`    | N/A                                                                 | N/A                                                                    | `0 5 * * 1-5`        | `0 17 * * 1-5`         |
| `nightlyzero_norecycle` | N/A                                                                 | N/A                                                                    | `0 5 * * 1-5`        | `0 21 * * 1-5`         |
| `nightlyzero_normal`    | `0 11,17 * * 1-5`                                                   | `15 11,17 * * 1-5`                                                     | `0 5 * * 1-5`        | `0 21 * * 1-5`         |
| `nightlyzero_business`  | `0 17 * * 1-5`                                                      | `15 17 * * 1-5`                                                        | `0 5 * * 1-5`        | `0 21 * * 1-5`         |
| `weeklyzero_norecycle`  | N/A                                                                 | N/A                                                                    | `0 5 * * 1`          | `0 17 * * 5`           |
| `weeklyzero_normal`     | <pre>0 11,17,23 * * 1<br>0 5,11,17,23 * * 2-4<br>0 5,11 * * 5</pre> | <pre>15 11,17,23 * * 1<br>15 5,11,17,23 * * 2-4<br>15 5,11 * * 5</pre> | `0 5 * * 1`          | `0 17 * * 5`           |
| `weeklyzero_business`   | `0 17 * * 1-4`                                                      | `15 17 * * 1-4`                                                        | `0 5 * * 1`          | `0 17 * * 5`           |

If desiring to use a different set of expressions for 'recycle' and/or 'zero out' schedules, `var.custom_schedule` can be used instead, e.g.:

```terraform
custom_schedule = {
  "asg_rotation_schedule" = {
    recycle_up    = ["0 11 * * 1-5"]
    recycle_down  = ["15 11 * * 1-5"]
    autozero_up   = ["0 5 * * 1-5"]
    autozero_down = ["0 17 * * 1-5"]
  }
}
```

To use a set of expressions, set `var.scale_schedule` to the name of the desired schedule, and the module will extract its corresponding 'recycle'/'zero out' schedules from the `local.rotation_schedules` map in `schedule.tf` (or `var.custom_schedule`, if using that instead).

## Examples

Using one of the schedules from `local.rotation_schedules` / `schedules.tf`:

```terraform
module "idp_recycle" {
  source = "github.com/18F/identity-terraform//asg_recycle?ref=main"

  asg_name                = aws_autoscaling_group.idp.name
  normal_desired_capacity = aws_autoscaling_group.idp.desired_capacity
  scale_schedule          = "nightlyzero_business"
}
```

Using `var.custom_schedule` and overrides for the multiplier, timezone, and spindown capacity:

```terraform
module "migration_recycle" {
  source = "github.com/18F/identity-terraform//asg_recycle?ref=main"

  asg_name                   = aws_autoscaling_group.migration.name
  normal_desired_capacity    = 1
  time_zone                  = "America/New_York"
  spinup_mult_factor         = 1
  override_spindown_capacity = 0
  scale_schedule             = "migration_nightlyzero_business"
  custom_schedule = {
    "migration_nightlyzero_business" = {
      recycle_up   = ["50 16 * * 1-5"]
      recycle_down = ["20 17 * * 1-5"]
      autozero_up  = ["50 4 * * *"]
      autozero_down = [
        "20 5 * * *",
        "50 20 * * *"
      ]
    }
  }
}
```

## Variables

| Name                         | Type    | Description                                                                                                                           | Required | Default            |
| ----                         | ----    | -----------                                                                                                                           | -------- | -------            |
| `asg_name`                   | string  | Name of the Auto Scaling Group to apply scheduled actions to                                                                          | YES      | N/A                |
| `normal_desired_capacity`    | number  | Default Desired capacity for the Auto Scaling Group                                                                                   | YES      | N/A                |
| `override_spindown_capacity` | number  | Set a specific number of instances for spindown instead of `normal_desired_capacity`                                                  | NO       | -1                 |
| `max_size`                   | number  | Default maximum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
| `min_size`                   | number  | Default minimum capacity for the Auto Scaling Group                                                                                   | NO       | -1                 |
| `spinup_mult_factor`         | number  | Multiplier for `normal_desired_capacity` to calculate Desired capacity (normal x mult) for the `auto-recycle.spinup` scheduled action | NO       | 2                  |
| `time_zone`                  | string  | IANA time zone to use with cron schedules (uses UTC by default)                                                                       | NO       | Etc/UTC            |
| `scale_schedule`             | string  | Name of a block in `local.rotation_schedules` or `var.custom_schedule` with `cron` schedules for the associated Scheduled Actions     | NO       | `nozero_norecycle` |
| `custom_schedule`            | `any`   | Customized set of cron jobs for recycling (up/down) and/or zeroing out hosts (overrides `local.rotation_schedules` if set)            | NO       | {}                 |