### PR TITLE
autozero schedules should not set min/max at 0

### DIFF
--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -40,8 +40,8 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
   for_each = toset(local.schedule["autozero_up"])
 
   scheduled_action_name  = "auto-zero.spinup"
-  min_size               = var.min_size <= 0 ? 1 : var.min_size
-  max_size               = var.max_size
+  min_size               = var.min_size
+  max_size               = var.max_size <= 0 ? 1 : var.max_size
   desired_capacity       = var.normal_desired_capacity
   recurrence             = each.key
   time_zone              = var.time_zone

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -34,12 +34,13 @@ resource "aws_autoscaling_schedule" "recycle_spindown" {
 # Spin down to 0 hosts, on a regular schedule. Depending upon selection,
 # do this either daily after working hours, weekly (same time), or nightly.
 # Follow a similar schedule to the recycle one above.
+# Ensure that ASG can spin down/up, instead of capping min/max at 0 hosts.
 
 resource "aws_autoscaling_schedule" "autozero_spinup" {
   for_each = toset(local.schedule["autozero_up"])
 
   scheduled_action_name  = "auto-zero.spinup"
-  min_size               = var.min_size
+  min_size               = var.min_size <= 0 ? 1 : var.min_size
   max_size               = var.max_size
   desired_capacity       = var.normal_desired_capacity
   recurrence             = each.key
@@ -51,8 +52,8 @@ resource "aws_autoscaling_schedule" "autozero_spindown" {
   for_each = toset(local.schedule["autozero_down"])
 
   scheduled_action_name  = "auto-zero.spindown"
-  min_size               = 0
-  max_size               = 0
+  min_size               = var.min_size > 0 ? 0 : var.min_size
+  max_size               = var.max_size
   desired_capacity       = 0
   recurrence             = each.key
   time_zone              = var.time_zone

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -39,10 +39,11 @@ resource "aws_autoscaling_schedule" "recycle_spindown" {
 resource "aws_autoscaling_schedule" "autozero_spinup" {
   for_each = toset(local.schedule["autozero_up"])
 
-  scheduled_action_name  = "auto-zero.spinup"
-  min_size               = var.min_size
-  max_size               = var.max_size <= 0 ? 1 : var.max_size
-  desired_capacity       = var.normal_desired_capacity
+  scheduled_action_name = "auto-zero.spinup"
+  min_size              = var.min_size
+  max_size              = var.max_size <= 0 ? 1 : var.max_size
+  desired_capacity = var.normal_desired_capacity > var.max_size ? (
+  var.max_size) : var.normal_desired_capacity
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name


### PR DESCRIPTION
When the number `-1` is provided to an `aws_autoscaling_schedule` resource, it translates to "don't touch this value" for whichever count type (Min/Max/Desired) it is pointing at; as a result, these schedules have traditionally only adjusted the Desired count by default. This PR fixes/updates the `autozero` schedules to follow the same template/formula, instead of setting all of the values for the ASGs to 0 (which can get in the way of the groups attempting to spin back up).

Additionally:
- If the Minimum count is 1 or more, and the Scheduled Action is attempting to spin DOWN an ASG, set Minimum to zero -- otherwise, leave it alone
- Similarly, if the Maximum count is 0 when attempting to spin UP a group, set it to 1 (and, similarly, leave it alone otherwise)