### PR TITLE
fixing autozero schedules with new 'normal' vars

### DIFF
--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -40,12 +40,12 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
   for_each = toset(local.schedule["autozero_up"])
 
   scheduled_action_name = "auto-zero.spinup"
-  min_size              = var.min_size
-  max_size = var.max_size == 0 ? (
-  var.min_size == 0 ? 1 : var.min_size) : var.max_size
+  min_size              = var.normal_min
+  max_size = var.normal_max == 0 ? (
+  var.normal_min == 0 ? 1 : var.normal_min) : var.normal_max
   desired_capacity = (
-    var.normal_desired > var.max_size || var.normal_desired < var.min_size ? (
-    var.max_size) : var.normal_desired
+    var.normal_desired > var.normal_max || var.normal_desired < var.normal_min ? (
+    var.normal_max) : var.normal_desired
   )
   recurrence             = each.key
   time_zone              = var.time_zone

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -12,7 +12,7 @@ resource "aws_autoscaling_schedule" "recycle_spinup" {
   scheduled_action_name  = "auto-recycle.spinup"
   min_size               = var.min_size
   max_size               = var.max_size
-  desired_capacity       = var.normal_desired_capacity * var.spinup_mult_factor
+  desired_capacity       = var.normal_desired * var.spinup_mult_factor
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
@@ -25,7 +25,7 @@ resource "aws_autoscaling_schedule" "recycle_spindown" {
   min_size              = var.min_size
   max_size              = var.max_size
   desired_capacity = var.override_spindown_capacity == -1 ? (
-  var.normal_desired_capacity) : var.override_spindown_capacity
+  var.normal_desired) : var.override_spindown_capacity
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
@@ -41,10 +41,12 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
 
   scheduled_action_name = "auto-zero.spinup"
   min_size              = var.min_size
-  max_size              = var.max_size == 0 ? (
+  max_size = var.max_size == 0 ? (
   var.min_size == 0 ? 1 : var.min_size) : var.max_size
-  desired_capacity = var.normal_desired_capacity > var.max_size ? (
-  var.max_size) : var.normal_desired_capacity
+  desired_capacity = (
+    var.normal_desired > var.max_size || var.normal_desired < var.min_size ? (
+    var.max_size) : var.normal_desired
+  )
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -41,7 +41,8 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
 
   scheduled_action_name = "auto-zero.spinup"
   min_size              = var.min_size
-  max_size              = var.max_size <= 0 ? 1 : var.max_size
+  max_size              = var.max_size == 0 ? (
+  var.min_size == 0 ? 1 : var.min_size) : var.max_size
   desired_capacity = var.normal_desired_capacity > var.max_size ? (
   var.max_size) : var.normal_desired_capacity
   recurrence             = each.key
@@ -53,7 +54,7 @@ resource "aws_autoscaling_schedule" "autozero_spindown" {
   for_each = toset(local.schedule["autozero_down"])
 
   scheduled_action_name  = "auto-zero.spindown"
-  min_size               = var.min_size > 0 ? 0 : var.min_size
+  min_size               = 0
   max_size               = var.max_size
   desired_capacity       = 0
   recurrence             = each.key

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -3,7 +3,7 @@ variable "asg_name" {
   type        = string
 }
 
-variable "normal_desired_capacity" {
+variable "normal_desired" {
   description = <<EOM
 Default Desired capacity for the Auto Scaling Group.
 Multiplied by spinup_mult_factor to set the Desired capacity for auto-recycle.spinup.
@@ -14,7 +14,7 @@ EOM
 
 variable "override_spindown_capacity" {
   description = <<EOM
-Set a specific number of instances for spindown instead of normal_desired_capacity.
+Set a specific number of instances for spindown instead of normal_desired.
 Will ONLY override the Desired capacity for the auto-recycle.spindown action.
 EOM
   type        = number
@@ -35,7 +35,7 @@ variable "min_size" {
 
 variable "spinup_mult_factor" {
   description = <<EOM
-Multiplier for normal_desired_capacity to calculate Desired capacity (normal x mult)
+Multiplier for normal_desired to calculate Desired capacity (normal x mult)
 for the auto-recycle.spinup scheduled action.
 EOM
   type        = number

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -3,15 +3,6 @@ variable "asg_name" {
   type        = string
 }
 
-variable "normal_desired" {
-  description = <<EOM
-Default Desired capacity for the Auto Scaling Group.
-Multiplied by spinup_mult_factor to set the Desired capacity for auto-recycle.spinup.
-Used for auto-recycle.spindown, unless override_spindown_capacity has been set.
-EOM
-  type        = number
-}
-
 variable "override_spindown_capacity" {
   description = <<EOM
 Set a specific number of instances for spindown instead of normal_desired.
@@ -31,6 +22,25 @@ variable "min_size" {
   description = "Default minimum capacity for the Auto Scaling Group."
   type        = number
   default     = -1
+}
+
+variable "normal_desired" {
+  description = <<EOM
+Default Desired capacity for the Auto Scaling Group.
+Multiplied by spinup_mult_factor to set the Desired capacity for auto-recycle.spinup.
+Used for auto-recycle.spindown, unless override_spindown_capacity has been set.
+EOM
+  type        = number
+}
+
+variable "normal_max" {
+  description = "Normal (post-autozero) maximum capacity for the Auto Scaling Group."
+  type        = number
+}
+
+variable "normal_min" {
+  description = "Normal (post-autozero) minimum capacity for the Auto Scaling Group."
+  type        = number
 }
 
 variable "spinup_mult_factor" {


### PR DESCRIPTION
Last (hopefully) tweak for the `asg_recycle` module -- this adds a new set of variables, all beginning with `normal`, which the `autozero-spinup` schedule uses to reset the target ASG back to its original numbers (when spinning back up from 0).

Using these variables negates the need to explicitly set the max/min/etc. for the other Scheduled Actions, which can still use the `-1` values as before.