### PR TITLE
add increments in action names when using multiple schedules in one Action

### DIFF
--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -19,10 +19,6 @@ resource "aws_autoscaling_schedule" "recycle_spinup" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_autoscaling_schedule" "recycle_spindown" {
@@ -39,10 +35,6 @@ resource "aws_autoscaling_schedule" "recycle_spindown" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 # Spin down to 0 hosts, on a regular schedule. Depending upon selection,
@@ -67,10 +59,6 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_autoscaling_schedule" "autozero_spindown" {
@@ -86,8 +74,4 @@ resource "aws_autoscaling_schedule" "autozero_spindown" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -19,6 +19,10 @@ resource "aws_autoscaling_schedule" "recycle_spinup" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_schedule" "recycle_spindown" {
@@ -35,6 +39,10 @@ resource "aws_autoscaling_schedule" "recycle_spindown" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Spin down to 0 hosts, on a regular schedule. Depending upon selection,
@@ -59,6 +67,10 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_schedule" "autozero_spindown" {
@@ -74,4 +86,8 @@ resource "aws_autoscaling_schedule" "autozero_spindown" {
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -9,7 +9,10 @@ locals {
 resource "aws_autoscaling_schedule" "recycle_spinup" {
   for_each = toset(local.schedule["recycle_up"])
 
-  scheduled_action_name  = "auto-recycle.spinup"
+  scheduled_action_name = join(".", [
+    "auto-recycle.spinup",
+    index(local.schedule["recycle_up"], each.key)
+  ])
   min_size               = var.min_size
   max_size               = var.max_size
   desired_capacity       = var.normal_desired * var.spinup_mult_factor
@@ -21,9 +24,12 @@ resource "aws_autoscaling_schedule" "recycle_spinup" {
 resource "aws_autoscaling_schedule" "recycle_spindown" {
   for_each = toset(local.schedule["recycle_down"])
 
-  scheduled_action_name = "auto-recycle.spindown"
-  min_size              = var.min_size
-  max_size              = var.max_size
+  scheduled_action_name = join(".", [
+    "auto-recycle.spindown",
+    index(local.schedule["recycle_down"], each.key)
+  ])
+  min_size = var.min_size
+  max_size = var.max_size
   desired_capacity = var.override_spindown_capacity == -1 ? (
   var.normal_desired) : var.override_spindown_capacity
   recurrence             = each.key
@@ -39,8 +45,11 @@ resource "aws_autoscaling_schedule" "recycle_spindown" {
 resource "aws_autoscaling_schedule" "autozero_spinup" {
   for_each = toset(local.schedule["autozero_up"])
 
-  scheduled_action_name = "auto-zero.spinup"
-  min_size              = var.normal_min
+  scheduled_action_name = join(".", [
+    "auto-zero.spinup",
+    index(local.schedule["autozero_up"], each.key)
+  ])
+  min_size = var.normal_min
   max_size = var.normal_max == 0 ? (
   var.normal_min == 0 ? 1 : var.normal_min) : var.normal_max
   desired_capacity = (
@@ -55,7 +64,10 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
 resource "aws_autoscaling_schedule" "autozero_spindown" {
   for_each = toset(local.schedule["autozero_down"])
 
-  scheduled_action_name  = "auto-zero.spindown"
+  scheduled_action_name = join(".", [
+    "auto-zero.spindown",
+    index(local.schedule["autozero_down"], each.key)
+  ])
   min_size               = 0
   max_size               = var.max_size
   desired_capacity       = 0


### PR DESCRIPTION
While the `asg_recycle` module has `for_each` logic in each resource -- to support the creation of multiple scheduled actions with the same counts and general name -- the resources all have the same static name, which causes Terraform to constantly loop through each schedule in its corresponding list and overwrite the Action accordingly, each time it runs. This adds a numerical iterator to the name of the Scheduled Action to prevent such resource clobbering.