### PR TITLE
update modules to support Terraform 1.3.5 + updated provider versions

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -182,7 +182,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -122,7 +122,7 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/iam_assumerole/main.tf
+++ b/iam_assumerole/main.tf
@@ -1,12 +1,3 @@
-# variable optional attributes will be fully supported in Terraform v1.3.x;
-# remove this section once that is officially released and confirmed working
-# 
-# more info: https://github.com/hashicorp/terraform/releases/tag/v1.3.0-alpha20220608
-
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 # -- Variables --
 
 variable "enabled" {

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -613,7 +613,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -800,7 +800,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source   = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source   = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   source_code_filename = "slack_lambda.py"
   source_dir           = "${path.module}/src/"

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   source_code_filename = "windowed_slo.py"
   source_dir           = "${path.module}/src/"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -134,7 +134,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -215,7 +215,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=0c1ffbdb1b5e8fe6a1813296c1425975014c8ca4"
+  source     = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/versions.tf
+++ b/versions.tf
@@ -22,5 +22,5 @@ terraform {
       source = "newrelic/newrelic"
     }
   }
-  required_version = ">= 1.2.4"
+  required_version = ">= 1.3.5"
 }


### PR DESCRIPTION
There's not a lot to this update, aside from the PR's title. The only particularly-notable change is the removal of the `module_variable_optional_attrs` experiment block, as that feature is now fully supported within Terraform 1.3; the other changes are circular gitsha updates.