### PR TITLE
remove spaces from CloudWatch metric alarm names

### DIFF
--- a/elb_http_alerts/main.tf
+++ b/elb_http_alerts/main.tf
@@ -50,7 +50,7 @@ locals {
 # -- Resources --
 
 resource "aws_cloudwatch_metric_alarm" "elb_http_5xx" {
-  alarm_name        = "${var.lb_name} ${var.lb_type} HTTP 5XX"
+  alarm_name        = "${var.lb_name}_${var.lb_type}_HTTP-5XX"
   alarm_description = <<EOM
 HTTP 5XX errors served by the ${var.lb_name} ${var.lb_type} without hosts
 EOM
@@ -77,7 +77,7 @@ EOM
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_http_5xx" {
-  alarm_name        = "${var.lb_name} Target HTTP 5XX"
+  alarm_name        = "${var.lb_name}_Target_HTTP-5XX"
   alarm_description = <<EOM
 HTTP 5XX errors served by hosts in ${var.lb_name} ${var.lb_type}
 EOM

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -38,7 +38,7 @@ variable "treat_missing_data" {
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate" {
   count = var.enabled
 
-  alarm_name        = "${var.function_name}_LambdaErrorRate"
+  alarm_name        = "LambdaErrorRate_${var.function_name}"
   alarm_description = "Lambda error rate has exceeded ${var.error_rate_threshold}%"
 
   comparison_operator       = "GreaterThanOrEqualToThreshold"

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -38,14 +38,16 @@ variable "treat_missing_data" {
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate" {
   count = var.enabled
 
-  alarm_name        = "Lambda error rate: ${var.function_name}"
+  alarm_name        = "${var.function_name}_LambdaErrorRate"
   alarm_description = "Lambda error rate has exceeded ${var.error_rate_threshold}%"
 
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = var.evaluation_periods
   threshold                 = var.error_rate_threshold
   insufficient_data_actions = []
+  datapoints_to_alarm       = var.datapoints_to_alarm
+  treat_missing_data        = var.treat_missing_data
+  alarm_actions             = var.alarm_actions
 
   metric_query {
     id          = "error_rate"
@@ -78,10 +80,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_rate" {
     }
   }
 
-  datapoints_to_alarm = var.datapoints_to_alarm
-
-  treat_missing_data = var.treat_missing_data
-
-  alarm_actions = var.alarm_actions
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 


### PR DESCRIPTION
In order to import an `aws_cloudwatch_metric_alarm` resource into Terraform state, one must supply the name of the alarm as an argument (which is also returned as the `id` of the created resource). This operation will fail if there are spaces in the name of the alarm, as `terraform import` only accepts 2 arguments (and gets confused by the spaces in the alarm name).

Therefore, this PR updates the various `aws_cloudwatch_metric_alarm` resources in this repo, replace the spaces in their names with hyphens and underscores.