### PR TITLE
Make kms_log more composable

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -528,9 +528,7 @@ resource "aws_cloudwatch_metric_alarm" "dead_letter" {
   threshold          = 1
   alarm_description  = "This alarm notifies when messages are on dead letter queue"
   treat_missing_data = "ignore"
-  alarm_actions = [
-    var.alarm_sns_topic_arn,
-  ]
+  alarm_actions      = var.alarm_sns_topic_arns
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_lambda_backlog" {
@@ -549,9 +547,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_lambda_backlog" {
   threshold          = 3600000
   alarm_description  = "Kinesis backlog for ${var.env_name}-cloudwatch-kms"
   treat_missing_data = "ignore"
-  alarm_actions = [
-    var.alarm_sns_topic_arn,
-  ]
+  alarm_actions      = var.alarm_sns_topic_arns
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudtrail_lambda_backlog" {
@@ -572,9 +568,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudtrail_lambda_backlog" {
   threshold          = 10000
   alarm_description  = "Kinesis backlog for ${var.env_name}-cloudtrail-kms"
   treat_missing_data = "ignore"
-  alarm_actions = [
-    var.alarm_sns_topic_arn,
-  ]
+  alarm_actions      = var.alarm_sns_topic_arns
 }
 
 #lambda functions
@@ -597,7 +591,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 
   environment {
     variables = {
-      DEBUG               = var.kmslog_lambda_debug == 1 ? "1" : ""
+      DEBUG               = var.kmslog_lambda_debug ? "1" : ""
       LOG_LEVEL           = "0"
       CT_QUEUE_URL        = aws_sqs_queue.kms_ct_events.id
       RETENTION_DAYS      = var.dynamodb_retention_days
@@ -617,7 +611,7 @@ module "ct-processor-github-alerts" {
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
-  alarm_actions        = [var.alarm_sns_topic_arn]
+  alarm_actions        = var.alarm_sns_topic_arns
   error_rate_threshold = 5 # percent
   datapoints_to_alarm  = 5
   evaluation_periods   = 5
@@ -785,7 +779,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 
   environment {
     variables = {
-      DEBUG               = var.kmslog_lambda_debug == 1 ? "1" : ""
+      DEBUG               = var.kmslog_lambda_debug ? "1" : ""
       LOG_LEVEL           = "0"
       RETENTION_DAYS      = var.dynamodb_retention_days
       DDB_TABLE           = aws_dynamodb_table.kms_events.id
@@ -804,7 +798,7 @@ module "cw-processor-github-alerts" {
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name
-  alarm_actions        = [var.alarm_sns_topic_arn]
+  alarm_actions        = var.alarm_sns_topic_arns
   error_rate_threshold = 5 # percent
   datapoints_to_alarm  = 5
   evaluation_periods   = 5
@@ -927,7 +921,7 @@ resource "aws_lambda_function" "event_processor" {
 
   environment {
     variables = {
-      DEBUG     = var.kmslog_lambda_debug == 1 ? "1" : ""
+      DEBUG     = var.kmslog_lambda_debug ? "1" : ""
       LOG_LEVEL = "0"
       ENV_NAME  = var.env_name
     }

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -59,13 +59,14 @@ variable "lambda_identity_lambda_functions_gitrev" {
 }
 
 variable "dynamodb_retention_days" {
-  default     = "365"
+  default     = 365
   description = "Number of days to retain kms log records in dynamodb"
 }
 
 variable "kmslog_lambda_debug" {
-  default     = 0
+  default     = false
   description = "Whether to run the kms logging lambdas in debug mode in this account"
+  type        = bool
 }
 
 variable "ec2_kms_arns" {
@@ -73,6 +74,8 @@ variable "ec2_kms_arns" {
   description = "ARN(s) of EC2 roles permitted access to KMS"
 }
 
-variable "alarm_sns_topic_arn" {
-  description = "SNS Topic ARN for alarms"
+variable "alarm_sns_topic_arns" {
+  description = "List of SNS Topic ARN for alarms"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
A few tweaks to make it possible to use the `kms_log` module without agreeing to drop a message bomb on a SNS topic if things go awry.