### PR TITLE
creation of guardduty module (detector/CW logs/S3 destination/KMS keys)

### DIFF
--- a/guardduty/README.md
+++ b/guardduty/README.md
@@ -23,21 +23,22 @@ module "guardduty_usw2" {
 
 ## Variables
 
-| Name                   | Type   | Description                                                                                                                                                  | Required | Default                  |
-| -----                  | -----  | -----                                                                                                                                                        | -----    | -----                    |
-| `region`               | string | AWS Region for the module.                                                                                                                                   | YES      | `us-west-2`              |
-| `bucket_name`          | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                | YES      | `guardduty`              |
-| `bucket_name_prefix`   | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                 | YES      | N/A                      |
-| `bucket_name_override` | string | Set this to override the normal bucket naming schema.                                                                                                        | NO       | N/A                      |
-| `log_bucket_name`      | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.        | NO       | N/A                      |
-| `inventory_bucket_arn` | string | Override ARN of the S3 Inventory reports bucket. Defaults to `arn:aws:s3:::$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                      |
-| `finding_freq`         | string | Frequency of notifications for GuardDuty findings.                                                                                                           | YES      | `SIX_HOURS`              |
-| `s3_enable`            | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                         | YES      | **false**                |
-| `k8s_audit_enable`     | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                   | YES      | **false**                |
-| `ec2_ebs_enable`       | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                   | YES      | **false**                |
-| `event_rule_name`      | string | Name for the GuardDuty Findings CloudWatch Event Rule.                                                                                                       | YES      | `GuardDutyFindings`      |
-| `log_group_name`       | string | Name of the CloudWatch Log Group to log GuardDuty findings.                                                                                                  | YES      | `/aws/events/gdfindings` |
-| `event_target_id`      | string | ID for the Event Target used for CloudWatch Logs.                                                                                                            | YES      | `GDFindingsToCWLogs`     |
+| Name                     | Type   | Description                                                                                                                                                  | Required | Default                         |
+| -----                    | -----  | -----                                                                                                                                                        | -----    | -----                           |
+| `region`                 | string | AWS Region for the module.                                                                                                                                   | YES      | `us-west-2`                     |
+| `bucket_name`            | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                | YES      | `guardduty`                     |
+| `bucket_name_prefix`     | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                 | YES      | N/A                             |
+| `bucket_name_override`   | string | Set this to override the normal bucket naming schema.                                                                                                        | NO       | N/A                             |
+| `log_bucket_name`        | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.        | NO       | N/A                             |
+| `inventory_bucket_arn`   | string | Override ARN of the S3 Inventory reports bucket. Defaults to `arn:aws:s3:::$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                             |
+| `finding_freq`           | string | Frequency of notifications for GuardDuty findings.                                                                                                           | YES      | `SIX_HOURS`                     |
+| `s3_enable`              | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                         | YES      | **false**                       |
+| `k8s_audit_enable`       | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                   | YES      | **false**                       |
+| `ec2_ebs_enable`         | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                   | YES      | **false**                       |
+| `cloudwatch_name`        | string | Name for the GuardDuty Findings CloudWatch Target/Event/Rule.                                                                                                | YES      | `GuardDutyFindings`             |
+| `log_group_id`           | string | ID of the CloudWatch Log Group to log GuardDuty findings.                                                                                                    | YES      | `/aws/events/gdfindings`        |
+| `event_target_id`        | string | ID for the Event Target used for CloudWatch Logs.                                                                                                            | YES      | `SendToCWLogGroup`              |
+| `publishing_policy_name` | string | Name of the CloudWatch Log Resource Policy used for log delivery.                                                                                            | YES      | `cw-rule-log-publishing-policy` |
 
 ## Outputs
 

--- a/guardduty/README.md
+++ b/guardduty/README.md
@@ -1,0 +1,50 @@
+# `guardduty`
+
+This module creates and manages a GuardDuty Detector for an AWS account (in a single region), along with associated resources:
+
+- S3 bucket used as a GuardDuty Publishing Destination + config resources (lifecycle/policy/logging/inventory/etc.)
+- KMS key/alias for Publishing Destination and S3 SSE + key policy
+- CloudWatch Event Rule triggered on GuardDuty Findings + Log Group / Event Target
+
+## Example
+
+```hcl
+module "guardduty_usw2" {
+  source = "github.com/18F/identity-terraform//guardduty?ref=main"
+
+  region                     = "us-west-2"
+  bucket_name_prefix         = local.bucket_name_prefix
+  guardduty_finding_freq     = "SIX_HOURS"
+  guardduty_s3_enable        = true
+  guardduty_k8s_audit_enable = false
+  guardduty_ec2_ebs_enable   = false
+}
+```
+
+## Variables
+
+| Name                    | Type   | Description                                                                                                                                                      | Required | Default                  |
+| -----                   | -----  | -----                                                                                                                                                            | -----    | -----                    |
+| `region`                | string | AWS Region for the module.                                                                                                                                       | YES      | `us-west-2`              |
+| `bucket_name`           | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                    | YES      | `guardduty`              |
+| `bucket_name_prefix`    | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                     | YES      | N/A                      |
+| `bucket_name_override`  | string | Set this to override the normal bucket naming schema.                                                                                                            | NO       | N/A                      |
+| `log_bucket_name`       | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.            | NO       | N/A                      |
+| `inventory_bucket_name` | string | Override name of the S3 bucket used for S3 Inventory reports. Will default to `$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                      |
+| `finding_freq`          | string | Frequency of notifications for GuardDuty findings.                                                                                                               | YES      | `SIX_HOURS`              |
+| `s3_enable`             | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                             | YES      | **false**                |
+| `k8s_audit_enable`      | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                       | YES      | **false**                |
+| `ec2_ebs_enable`        | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                       | YES      | **false**                |
+| `event_rule_prefix`     | string | Prefix string used to name the GuardDuty Findings CloudWatch Event Rule in the form `$event_rule_prefix-$region.`                                                | YES      | `GuardDutyFindings`      |
+| `log_group_name`        | string | Name of the CloudWatch Log Group to log GuardDuty findings.                                                                                                      | YES      | `/aws/events/gdfindings` |
+| `event_target_id`       | string | ID for the Event Target used for CloudWatch Logs.                                                                                                                | YES      | `GDFindingsToCWLogs`     |
+
+## Outputs
+
+| Name                     | Description                                                | Value                                              |
+| -----                    | -----                                                      | -----                                              |
+| `detector_id`            | ID of the GuardDuty Detector.                              | `aws_guardduty_detector.main.id`                   |
+| `publishing_destination` | ID of the GuardDuty Publishing Destination (S3).           | `aws_guardduty_publishing_destination.s3.id`       |
+| `cw_log_group`           | Name of the GuardDuty Findings CloudWatch Log Group.       | `aws_cloudwatch_log_group.guardduty_findings.name` |
+| `kms_key_id`             | ID of the KMS key used to encrypt GuardDuty publishing.    | `aws_kms_key.guardduty.key_id`                     |
+| `kms_key_alias`          | Alias of the KMS key used to encrypt GuardDuty publishing. | `aws_kms_alias.guardduty.name`                     |

--- a/guardduty/README.md
+++ b/guardduty/README.md
@@ -23,21 +23,21 @@ module "guardduty_usw2" {
 
 ## Variables
 
-| Name                    | Type   | Description                                                                                                                                                  | Required | Default                  |
-| -----                   | -----  | -----                                                                                                                                                        | -----    | -----                    |
-| `region`                | string | AWS Region for the module.                                                                                                                                   | YES      | `us-west-2`              |
-| `bucket_name`           | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                | YES      | `guardduty`              |
-| `bucket_name_prefix`    | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                 | YES      | N/A                      |
-| `bucket_name_override`  | string | Set this to override the normal bucket naming schema.                                                                                                        | NO       | N/A                      |
-| `log_bucket_name`       | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.        | NO       | N/A                      |
-| `inventory_bucket_arn`  | string | Override ARN of the S3 Inventory reports bucket. Defaults to `arn:aws:s3:::$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                      |
-| `finding_freq`          | string | Frequency of notifications for GuardDuty findings.                                                                                                           | YES      | `SIX_HOURS`              |
-| `s3_enable`             | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                         | YES      | **false**                |
-| `k8s_audit_enable`      | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                   | YES      | **false**                |
-| `ec2_ebs_enable`        | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                   | YES      | **false**                |
-| `event_rule_prefix`     | string | Prefix string used to name the GuardDuty Findings CloudWatch Event Rule in the form `$event_rule_prefix-$region.`                                            | YES      | `GuardDutyFindings`      |
-| `log_group_name`        | string | Name of the CloudWatch Log Group to log GuardDuty findings.                                                                                                  | YES      | `/aws/events/gdfindings` |
-| `event_target_id`       | string | ID for the Event Target used for CloudWatch Logs.                                                                                                            | YES      | `GDFindingsToCWLogs`     |
+| Name                   | Type   | Description                                                                                                                                                  | Required | Default                  |
+| -----                  | -----  | -----                                                                                                                                                        | -----    | -----                    |
+| `region`               | string | AWS Region for the module.                                                                                                                                   | YES      | `us-west-2`              |
+| `bucket_name`          | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                | YES      | `guardduty`              |
+| `bucket_name_prefix`   | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                 | YES      | N/A                      |
+| `bucket_name_override` | string | Set this to override the normal bucket naming schema.                                                                                                        | NO       | N/A                      |
+| `log_bucket_name`      | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.        | NO       | N/A                      |
+| `inventory_bucket_arn` | string | Override ARN of the S3 Inventory reports bucket. Defaults to `arn:aws:s3:::$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                      |
+| `finding_freq`         | string | Frequency of notifications for GuardDuty findings.                                                                                                           | YES      | `SIX_HOURS`              |
+| `s3_enable`            | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                         | YES      | **false**                |
+| `k8s_audit_enable`     | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                   | YES      | **false**                |
+| `ec2_ebs_enable`       | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                   | YES      | **false**                |
+| `event_rule_name`      | string | Name for the GuardDuty Findings CloudWatch Event Rule.                                                                                                       | YES      | `GuardDutyFindings`      |
+| `log_group_name`       | string | Name of the CloudWatch Log Group to log GuardDuty findings.                                                                                                  | YES      | `/aws/events/gdfindings` |
+| `event_target_id`      | string | ID for the Event Target used for CloudWatch Logs.                                                                                                            | YES      | `GDFindingsToCWLogs`     |
 
 ## Outputs
 

--- a/guardduty/README.md
+++ b/guardduty/README.md
@@ -23,21 +23,21 @@ module "guardduty_usw2" {
 
 ## Variables
 
-| Name                    | Type   | Description                                                                                                                                                      | Required | Default                  |
-| -----                   | -----  | -----                                                                                                                                                            | -----    | -----                    |
-| `region`                | string | AWS Region for the module.                                                                                                                                       | YES      | `us-west-2`              |
-| `bucket_name`           | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                    | YES      | `guardduty`              |
-| `bucket_name_prefix`    | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                     | YES      | N/A                      |
-| `bucket_name_override`  | string | Set this to override the normal bucket naming schema.                                                                                                            | NO       | N/A                      |
-| `log_bucket_name`       | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.            | NO       | N/A                      |
-| `inventory_bucket_name` | string | Override name of the S3 bucket used for S3 Inventory reports. Will default to `$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                      |
-| `finding_freq`          | string | Frequency of notifications for GuardDuty findings.                                                                                                               | YES      | `SIX_HOURS`              |
-| `s3_enable`             | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                             | YES      | **false**                |
-| `k8s_audit_enable`      | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                       | YES      | **false**                |
-| `ec2_ebs_enable`        | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                       | YES      | **false**                |
-| `event_rule_prefix`     | string | Prefix string used to name the GuardDuty Findings CloudWatch Event Rule in the form `$event_rule_prefix-$region.`                                                | YES      | `GuardDutyFindings`      |
-| `log_group_name`        | string | Name of the CloudWatch Log Group to log GuardDuty findings.                                                                                                      | YES      | `/aws/events/gdfindings` |
-| `event_target_id`       | string | ID for the Event Target used for CloudWatch Logs.                                                                                                                | YES      | `GDFindingsToCWLogs`     |
+| Name                    | Type   | Description                                                                                                                                                  | Required | Default                  |
+| -----                   | -----  | -----                                                                                                                                                        | -----    | -----                    |
+| `region`                | string | AWS Region for the module.                                                                                                                                   | YES      | `us-west-2`              |
+| `bucket_name`           | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                | YES      | `guardduty`              |
+| `bucket_name_prefix`    | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                 | YES      | N/A                      |
+| `bucket_name_override`  | string | Set this to override the normal bucket naming schema.                                                                                                        | NO       | N/A                      |
+| `log_bucket_name`       | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.        | NO       | N/A                      |
+| `inventory_bucket_arn`  | string | Override ARN of the S3 Inventory reports bucket. Defaults to `arn:aws:s3:::$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                      |
+| `finding_freq`          | string | Frequency of notifications for GuardDuty findings.                                                                                                           | YES      | `SIX_HOURS`              |
+| `s3_enable`             | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                         | YES      | **false**                |
+| `k8s_audit_enable`      | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                   | YES      | **false**                |
+| `ec2_ebs_enable`        | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                   | YES      | **false**                |
+| `event_rule_prefix`     | string | Prefix string used to name the GuardDuty Findings CloudWatch Event Rule in the form `$event_rule_prefix-$region.`                                            | YES      | `GuardDutyFindings`      |
+| `log_group_name`        | string | Name of the CloudWatch Log Group to log GuardDuty findings.                                                                                                  | YES      | `/aws/events/gdfindings` |
+| `event_target_id`       | string | ID for the Event Target used for CloudWatch Logs.                                                                                                            | YES      | `GDFindingsToCWLogs`     |
 
 ## Outputs
 

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -279,10 +279,10 @@ module "guardduty_bucket_config" {
 # CloudWatch Event Logging
 
 resource "aws_cloudwatch_event_rule" "guardduty_findings" {
-  name        = var.event_rule_name
+  name        = var.cloudwatch_name
   description = "Send GuardDuty findings to CW Log Groups"
   tags = {
-    "Name" = var.event_rule_name
+    "Name" = var.cloudwatch_name
   }
 
   event_pattern = <<EOM
@@ -298,10 +298,10 @@ EOM
 }
 
 resource "aws_cloudwatch_log_group" "guardduty_findings" {
-  name              = var.log_group_name
+  name              = var.log_group_id
   retention_in_days = 365
   tags = {
-    "Name" = var.event_rule_name
+    "Name" = var.cloudwatch_name
   }
 }
 
@@ -334,5 +334,5 @@ data "aws_iam_policy_document" "delivery_events_logs" {
 
 resource "aws_cloudwatch_log_resource_policy" "delivery_events_logs" {
   policy_document = data.aws_iam_policy_document.delivery_events_logs.json
-  policy_name     = "cw-rule-log-publishing-policy"
+  policy_name     = var.publishing_policy_name
 }

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -273,7 +273,7 @@ module "guardduty_bucket_config" {
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "guardduty"
   region               = var.region
-  inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"
+  inventory_bucket_arn = local.inventory_bucket_arn
 }
 
 # CloudWatch Event Logging

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -301,7 +301,7 @@ resource "aws_cloudwatch_log_group" "guardduty_findings" {
   name              = var.log_group_name
   retention_in_days = 365
   tags = {
-    "Name" = var.log_group_name
+    "Name" = var.event_rule_name
   }
 }
 

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -334,5 +334,5 @@ data "aws_iam_policy_document" "delivery_events_logs" {
 
 resource "aws_cloudwatch_log_resource_policy" "delivery_events_logs" {
   policy_document = data.aws_iam_policy_document.delivery_events_logs.json
-  policy_name     = "delivery_events_logs"
+  policy_name     = "cw-rule-log-publishing-policy"
 }

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -279,10 +279,10 @@ module "guardduty_bucket_config" {
 # CloudWatch Event Logging
 
 resource "aws_cloudwatch_event_rule" "guardduty_findings" {
-  name        = "${var.event_rule_prefix}-${var.region}"
-  description = "Send GuardDuty findings in ${var.region} to CW Log Groups"
+  name        = var.event_rule_name
+  description = "Send GuardDuty findings to CW Log Groups"
   tags = {
-    "Name" = "${var.event_rule_prefix}-${var.region}"
+    "Name" = var.event_rule_name
   }
 
   event_pattern = <<EOM

--- a/guardduty/outputs.tf
+++ b/guardduty/outputs.tf
@@ -1,0 +1,24 @@
+output "detector_id" {
+  description = "ID of the GuardDuty Detector."
+  value       = aws_guardduty_detector.main.id
+}
+
+output "publishing_destination" {
+  description = "ID of the GuardDuty Publishing Destination (S3)."
+  value       = aws_guardduty_publishing_destination.s3.id
+}
+
+output "cw_log_group" {
+  description = "Name of the GuardDuty Findings CloudWatch Log Group."
+  value       = aws_cloudwatch_log_group.guardduty_findings.name
+}
+
+output "kms_key_id" {
+  description = "ID of the KMS key used to encrypt GuardDuty publishing."
+  value       = aws_kms_key.guardduty.key_id
+}
+
+output "kms_key_alias" {
+  description = "Alias of the KMS key used to encrypt GuardDuty publishing."
+  value       = aws_kms_alias.guardduty.name
+}

--- a/guardduty/variables.tf
+++ b/guardduty/variables.tf
@@ -16,9 +16,9 @@ locals {
     var.log_bucket_name) : join(".",
     [var.bucket_name_prefix, "s3-access-logs", local.bucket_name_suffix]
   )
-  inventory_bucket = var.inventory_bucket_name != "" ? (
-    var.inventory_bucket_name) : join(".",
-    [var.bucket_name_prefix, "s3-inventory", local.bucket_name_suffix]
+  inventory_bucket_arn = var.inventory_bucket_arn != "" ? (
+    var.inventory_bucket_arn) : join(".",
+    ["arn:aws:s3:::${var.bucket_name_prefix}", "s3-inventory", local.bucket_name_suffix]
   )
 }
 
@@ -63,11 +63,11 @@ EOM
   default     = ""
 }
 
-variable "inventory_bucket_name" {
+variable "inventory_bucket_arn" {
   type        = string
   description = <<EOM
-Override name of the S3 bucket used for S3 Inventory reports.
-Will default to $bucket_name_prefix.s3-inventory.$account_id-$region
+Override ARN of the S3 Inventory reports bucket.
+Defaults to arn:aws:s3:::$bucket_name_prefix.s3-inventory.$account_id-$region
 if not explicitly declared.
 EOM
   default     = ""

--- a/guardduty/variables.tf
+++ b/guardduty/variables.tf
@@ -103,15 +103,15 @@ EOM
   default     = false
 }
 
-variable "event_rule_name" {
+variable "cloudwatch_name" {
   type        = string
-  description = "Name for the GuardDuty Findings CloudWatch Event Rule."
+  description = "Name for the GuardDuty Findings CloudWatch Target/Event/Rule."
   default     = "GuardDutyFindings"
 }
 
-variable "log_group_name" {
+variable "log_group_id" {
   type        = string
-  description = "Name of the CloudWatch Log Group to log GuardDuty findings."
+  description = "ID of the CloudWatch Log Group to log GuardDuty findings."
   default     = "/aws/events/gdfindings"
 }
 
@@ -121,3 +121,8 @@ variable "event_target_id" {
   default     = "SendToCWLogGroup"
 }
 
+variable "publishing_policy_name" {
+  type        = string
+  description = "Name of the CloudWatch Log Resource Policy used for log delivery."
+  default     = "cw-rule-log-publishing-policy"
+}

--- a/guardduty/variables.tf
+++ b/guardduty/variables.tf
@@ -103,12 +103,9 @@ EOM
   default     = false
 }
 
-variable "event_rule_prefix" {
+variable "event_rule_name" {
   type        = string
-  description = <<EOM
-Prefix string used to name the GuardDuty Findings CloudWatch Event Rule
-in the form $event_rule_prefix-$region.
-EOM
+  description = "Name for the GuardDuty Findings CloudWatch Event Rule."
   default     = "GuardDutyFindings"
 }
 
@@ -121,6 +118,6 @@ variable "log_group_name" {
 variable "event_target_id" {
   type        = string
   description = "ID for the Event Target used for CloudWatch Logs."
-  default     = "GDFindingsToCWLogs"
+  default     = "SendToCWLogGroup"
 }
 

--- a/guardduty/variables.tf
+++ b/guardduty/variables.tf
@@ -33,8 +33,8 @@ variable "region" {
 variable "bucket_name" {
   type        = string
   description = <<EOM
-REQUIRED. Second substring in S3 bucket name of
-$bucket_name_prefix.$bucket_name.$account_id-$region
+Second substring in S3 bucket name of
+$bucket_name_prefix.$bucket_name.$account_id-$region.
 EOM
   default     = "guardduty"
 }
@@ -42,21 +42,21 @@ EOM
 variable "bucket_name_prefix" {
   type        = string
   description = <<EOM
-REQUIRED. First substring in S3 bucket name of
-$bucket_name_prefix.$bucket_name.$account_id-$region
+First substring in S3 bucket name of
+$bucket_name_prefix.$bucket_name.$account_id-$region.
 EOM
 }
 
 variable "bucket_name_override" {
-  description = "Set this to override the normal bucket naming schema."
   type        = string
+  description = "Set this to override the normal bucket naming schema."
   default     = ""
 }
 
 variable "log_bucket_name" {
   type        = string
   description = <<EOM
-(OPTIONAL) Override name of the bucket used for S3 logging.
+Override name of the bucket used for S3 logging.
 Will default to $bucket_name_prefix.s3-access-logs.$account_id-$region
 if not explicitly declared.
 EOM
@@ -66,7 +66,7 @@ EOM
 variable "inventory_bucket_name" {
   type        = string
   description = <<EOM
-(OPTIONAL) Override name of the S3 bucket used for S3 Inventory reports.
+Override name of the S3 bucket used for S3 Inventory reports.
 Will default to $bucket_name_prefix.s3-inventory.$account_id-$region
 if not explicitly declared.
 EOM
@@ -106,7 +106,7 @@ EOM
 variable "event_rule_prefix" {
   type        = string
   description = <<EOM
-Prefix string used to name the GuardDuty Findings CloudWatch Event Rule,
+Prefix string used to name the GuardDuty Findings CloudWatch Event Rule
 in the form $event_rule_prefix-$region.
 EOM
   default     = "GuardDutyFindings"

--- a/guardduty/variables.tf
+++ b/guardduty/variables.tf
@@ -1,0 +1,87 @@
+# Locals
+
+locals {
+  gd_perm_conditions = [
+    {
+      "variable" = "aws:SourceAccount",
+      "values"   = [data.aws_caller_identity.current.account_id]
+    },
+    {
+      "variable" = "aws:SourceArn",
+      "values"   = [aws_guardduty_detector.main.arn]
+    }
+  ]
+  bucket_name_suffix = "${data.aws_caller_identity.current.account_id}-${var.region}"
+  log_bucket = var.log_bucket_name != "" ? (
+    var.log_bucket_name) : join(".",
+    [var.bucket_name_prefix, "s3-access-logs", local.bucket_name_suffix]
+  )
+  inventory_bucket = var.inventory_bucket_name != "" ? (
+    var.inventory_bucket_name) : join(".",
+    [var.bucket_name_prefix, "s3-inventory", local.bucket_name_suffix]
+  )
+}
+
+# Variables
+
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "bucket_name_prefix" {
+  description = <<EOM
+REQUIRED. First substring in S3 bucket name of
+$bucket_name_prefix.$env_name-guardduty.$account_id-$region
+EOM
+  type        = string
+}
+
+variable "log_bucket_name" {
+  description = <<EOM
+(OPTIONAL) Override name of the bucket used for S3 logging.
+Will default to $bucket_name_prefix.s3-access-logs.$account_id-$region
+if not explicitly declared.
+EOM
+  type        = string
+  default     = ""
+}
+
+variable "inventory_bucket_name" {
+  description = <<EOM
+(OPTIONAL) Override name of the S3 bucket used for S3 Inventory reports.
+Will default to $bucket_name_prefix.s3-inventory.$account_id-$region
+if not explicitly declared.
+EOM
+  type        = string
+  default     = ""
+}
+
+variable "finding_freq" {
+  type        = string
+  description = "Frequency of notifications for GuardDuty findings."
+  default     = "SIX_HOURS"
+}
+
+variable "s3_enable" {
+  type        = bool
+  description = "Whether or not to enable S3 protection in GuardDuty."
+  default     = false
+}
+
+variable "k8s_audit_enable" {
+  type        = bool
+  description = <<EOM
+Whether or not to enable Kubernetes audit logs as a data source
+for Kubernetes protection (via GuardDuty).
+EOM
+  default     = false
+}
+
+variable "ec2_ebs_enable" {
+  type        = bool
+  description = <<EOM
+Whether or not to enable Malware Protection (via scanning EBS volumes)
+as a data source for EC2 instances (via GuardDuty).
+EOM
+  default     = false
+}

--- a/guardduty/variables.tf
+++ b/guardduty/variables.tf
@@ -25,34 +25,51 @@ locals {
 # Variables
 
 variable "region" {
-  default = "us-west-2"
+  type        = string
+  description = "AWS Region for the module."
+  default     = "us-west-2"
+}
+
+variable "bucket_name" {
+  type        = string
+  description = <<EOM
+REQUIRED. Second substring in S3 bucket name of
+$bucket_name_prefix.$bucket_name.$account_id-$region
+EOM
+  default     = "guardduty"
 }
 
 variable "bucket_name_prefix" {
+  type        = string
   description = <<EOM
 REQUIRED. First substring in S3 bucket name of
-$bucket_name_prefix.$env_name-guardduty.$account_id-$region
+$bucket_name_prefix.$bucket_name.$account_id-$region
 EOM
+}
+
+variable "bucket_name_override" {
+  description = "Set this to override the normal bucket naming schema."
   type        = string
+  default     = ""
 }
 
 variable "log_bucket_name" {
+  type        = string
   description = <<EOM
 (OPTIONAL) Override name of the bucket used for S3 logging.
 Will default to $bucket_name_prefix.s3-access-logs.$account_id-$region
 if not explicitly declared.
 EOM
-  type        = string
   default     = ""
 }
 
 variable "inventory_bucket_name" {
+  type        = string
   description = <<EOM
 (OPTIONAL) Override name of the S3 bucket used for S3 Inventory reports.
 Will default to $bucket_name_prefix.s3-inventory.$account_id-$region
 if not explicitly declared.
 EOM
-  type        = string
   default     = ""
 }
 
@@ -85,3 +102,25 @@ as a data source for EC2 instances (via GuardDuty).
 EOM
   default     = false
 }
+
+variable "event_rule_prefix" {
+  type        = string
+  description = <<EOM
+Prefix string used to name the GuardDuty Findings CloudWatch Event Rule,
+in the form $event_rule_prefix-$region.
+EOM
+  default     = "GuardDutyFindings"
+}
+
+variable "log_group_name" {
+  type        = string
+  description = "Name of the CloudWatch Log Group to log GuardDuty findings."
+  default     = "/aws/events/gdfindings"
+}
+
+variable "event_target_id" {
+  type        = string
+  description = "ID for the Event Target used for CloudWatch Logs."
+  default     = "GDFindingsToCWLogs"
+}
+

--- a/guardduty/versions.tf
+++ b/guardduty/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf


### PR DESCRIPTION
_(The below information is pulled directly from the README for the `guardduty` module.)_

This module creates and manages a GuardDuty Detector for an AWS account (in a single region), along with associated resources:

- S3 bucket used as a GuardDuty Publishing Destination + config resources (lifecycle/policy/logging/inventory/etc.)
- KMS key/alias for Publishing Destination and S3 SSE + key policy
- CloudWatch Event Rule triggered on GuardDuty Findings + Log Group / Event Target

## Example

```hcl
module "guardduty_usw2" {
  source = "github.com/18F/identity-terraform//guardduty?ref=main"

  region                     = "us-west-2"
  bucket_name_prefix         = local.bucket_name_prefix
  guardduty_finding_freq     = "SIX_HOURS"
  guardduty_s3_enable        = true
  guardduty_k8s_audit_enable = false
  guardduty_ec2_ebs_enable   = false
}
```

## Variables

| Name                     | Type   | Description                                                                                                                                                  | Required | Default                         |
| -----                    | -----  | -----                                                                                                                                                        | -----    | -----                           |
| `region`                 | string | AWS Region for the module.                                                                                                                                   | YES      | `us-west-2`                     |
| `bucket_name`            | string | Second substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                | YES      | `guardduty`                     |
| `bucket_name_prefix`     | string | First substring in S3 bucket name of `$bucket_name_prefix.$bucket_name.$account_id-$region`.                                                                 | YES      | N/A                             |
| `bucket_name_override`   | string | Set this to override the normal bucket naming schema.                                                                                                        | NO       | N/A                             |
| `log_bucket_name`        | string | Override name of the bucket used for S3 logging. Will default to `$bucket_name_prefix.s3-access-logs.$account_id-$region` if not explicitly declared.        | NO       | N/A                             |
| `inventory_bucket_arn`   | string | Override ARN of the S3 Inventory reports bucket. Defaults to `arn:aws:s3:::$bucket_name_prefix.s3-inventory.$account_id-$region` if not explicitly declared. | NO       | N/A                             |
| `finding_freq`           | string | Frequency of notifications for GuardDuty findings.                                                                                                           | YES      | `SIX_HOURS`                     |
| `s3_enable`              | bool   | Whether or not to enable S3 protection in GuardDuty.                                                                                                         | YES      | **false**                       |
| `k8s_audit_enable`       | bool   | Whether or not to enable Kubernetes audit logs as a data source for Kubernetes protection (via GuardDuty).                                                   | YES      | **false**                       |
| `ec2_ebs_enable`         | bool   | Whether or not to enable Malware Protection (via scanning EBS volumes) as a data source for EC2 instances (via GuardDuty).                                   | YES      | **false**                       |
| `cloudwatch_name`        | string | Name for the GuardDuty Findings CloudWatch Target/Event/Rule.                                                                                                | YES      | `GuardDutyFindings`             |
| `log_group_id`           | string | ID of the CloudWatch Log Group to log GuardDuty findings.                                                                                                    | YES      | `/aws/events/gdfindings`        |
| `event_target_id`        | string | ID for the Event Target used for CloudWatch Logs.                                                                                                            | YES      | `SendToCWLogGroup`              |
| `publishing_policy_name` | string | Name of the CloudWatch Log Resource Policy used for log delivery.                                                                                            | YES      | `cw-rule-log-publishing-policy` |

## Outputs

| Name                     | Description                                                | Value                                              |
| -----                    | -----                                                      | -----                                              |
| `detector_id`            | ID of the GuardDuty Detector.                              | `aws_guardduty_detector.main.id`                   |
| `publishing_destination` | ID of the GuardDuty Publishing Destination (S3).           | `aws_guardduty_publishing_destination.s3.id`       |
| `cw_log_group`           | Name of the GuardDuty Findings CloudWatch Log Group.       | `aws_cloudwatch_log_group.guardduty_findings.name` |
| `kms_key_id`             | ID of the KMS key used to encrypt GuardDuty publishing.    | `aws_kms_key.guardduty.key_id`                     |
| `kms_key_alias`          | Alias of the KMS key used to encrypt GuardDuty publishing. | `aws_kms_alias.guardduty.name`                     |