### PR TITLE
also catch TERM in ssm_session Documents

### DIFF
--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -237,7 +237,7 @@ inputs:
   %{if each.value["use_root"] == "false"}runAsEnabled: true
   runAsDefaultUser: ''%{endif}
   shellProfile:
-    linux: 'trap "exit 0" INT; ${each.value["command"]} ; exit'
+    linux: 'trap "exit 0" INT TERM; ${each.value["command"]} ; exit'
   DOC
 }
 


### PR DESCRIPTION
Does what it says on the tin! Given the signals from `stty -a`:

```
cchars: discard = ^O; dsusp = ^Y; eof = ^D; eol = <undef>;
        eol2 = <undef>; erase = ^?; intr = ^C; kill = ^U; lnext = ^V;
        min = 1; quit = ^\; reprint = ^R; start = ^Q; status = ^T;
        stop = ^S; susp = ^Z; time = 0; werase = ^W;
```

...this change stops `CTRL+C`, `CTRL+Z`, `CTRL+D`, and `CTRL+\` (the other signals simply don't trigger any form of response).