### PR TITLE
add/update local/relative-path 'source' lines

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -182,7 +182,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -182,8 +182,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 
 module "s3_config" {
-  #source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
-  source = "../s3_config"
+  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -182,7 +182,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "elb-logs"

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -122,7 +122,8 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "../s3_config"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -122,7 +122,7 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
 }
 
 module "s3_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -122,8 +122,8 @@ resource "aws_s3_bucket_logging" "artifact_bucket" {
 }
 
 module "s3_config" {
-  #source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
-  source = "../s3_config"
+  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "../s3_config"
 
   bucket_name_override = aws_s3_bucket.artifact_bucket.id
   region               = var.region

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -268,7 +268,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "guardduty" {
 }
 
 module "guardduty_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=7445ae915936990bc52109087d92e5f9564f0f7c"
+  #source = "github.com/18F/identity-terraform//s3_config?ref=7445ae915936990bc52109087d92e5f9564f0f7c"
+  source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "guardduty"

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -268,8 +268,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "guardduty" {
 }
 
 module "guardduty_bucket_config" {
-  #source = "github.com/18F/identity-terraform//s3_config?ref=7445ae915936990bc52109087d92e5f9564f0f7c"
-  source = "../s3_config"
+  source = "github.com/18F/identity-terraform//s3_config?ref=7445ae915936990bc52109087d92e5f9564f0f7c"
+  #source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = "guardduty"

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -268,7 +268,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "guardduty" {
 }
 
 module "guardduty_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=7445ae915936990bc52109087d92e5f9564f0f7c"
+  source = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -607,7 +607,8 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  #source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  source = "../lambda_alerts"
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -794,7 +795,8 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  #source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  source = "../lambda_alerts"
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -607,8 +607,8 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  #source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
-  source = "../lambda_alerts"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  #source = "../lambda_alerts"
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -795,8 +795,8 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  #source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
-  source = "../lambda_alerts"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  #source = "../lambda_alerts"
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -607,7 +607,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../lambda_alerts"
 
   enabled              = 1
@@ -795,7 +795,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  source = "github.com/18F/identity-terraform//lambda_alerts?ref=b38d110e028926ad3fd90b4dcb03cc5001e65af1"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../lambda_alerts"
 
   enabled              = 1

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source   = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source   = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -115,8 +115,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  #source   = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
-  source = "../s3_config"
+  source   = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -115,7 +115,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 module "bucket_config" {
   for_each = var.bucket_data
-  source   = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source   = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "../s3_config"
 
   bucket_name_prefix   = var.bucket_name_prefix
   bucket_name          = each.key

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,8 +43,8 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  #source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
-  source = "../null_archive"
+  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "../null_archive"
 
   source_code_filename = "slack_lambda.py"
   source_dir           = "${path.module}/src/"

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "github.com/18F/identity-terraform//null_archive?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../null_archive"
 
   source_code_filename = "slack_lambda.py"

--- a/slack_lambda/main.tf
+++ b/slack_lambda/main.tf
@@ -43,7 +43,8 @@ data "aws_iam_policy_document" "lambda_policy" {
 }
 
 module "lambda_code" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "../null_archive"
 
   source_code_filename = "slack_lambda.py"
   source_dir           = "${path.module}/src/"

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,7 +66,8 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "../null_archive"
 
   source_code_filename = "windowed_slo.py"
   source_dir           = "${path.module}/src/"

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "github.com/18F/identity-terraform//null_archive?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../null_archive"
 
   source_code_filename = "windowed_slo.py"

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -66,8 +66,8 @@ resource "aws_iam_role_policy_attachment" "windowed_slo_lambda_execution_role" {
 }
 
 module "lambda_zip" {
-  #source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
-  source = "../null_archive"
+  source = "github.com/18F/identity-terraform//null_archive?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "../null_archive"
 
   source_code_filename = "windowed_slo.py"
   source_dir           = "${path.module}/src/"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -134,7 +134,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "../s3_config"
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -134,7 +134,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -134,8 +134,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {
 }
 
 module "ssm_logs_bucket_config" {
-  #source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
-  source = "../s3_config"
+  source = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "../s3_config"
 
   bucket_name_override = aws_s3_bucket.ssm_logs.id
   inventory_bucket_arn = "arn:aws:s3:::${local.inventory_bucket}"

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -215,7 +215,7 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source     = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
   depends_on = [aws_s3_bucket.s3-access-logs]
 

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -215,7 +215,8 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source     = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  source = "../s3_config"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -215,8 +215,8 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 
 module "s3_config" {
   for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  #source     = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
-  source = "../s3_config"
+  source     = "github.com/18F/identity-terraform//s3_config?ref=981497a941de179ce72d1a383b2973962c04d4c6"
+  #source = "../s3_config"
   depends_on = [aws_s3_bucket.s3-access-logs]
 
   bucket_name_prefix   = var.bucket_name_prefix


### PR DESCRIPTION
Does what it says on the tin! This adds an additional commented-out 'source' line to each `module` block in this repo, which can be uncommented/switched with the gitsha 'source' for faster/simpler module interconnectivity, and/or if GitHub is unreachable by Terraform.