### PR TITLE
add InteractiveCommand doc creation + additional CW resources to ssm module

### DIFF
--- a/ssm/README.md
+++ b/ssm/README.md
@@ -66,23 +66,19 @@ module "ssm" {
       command     = "sudo su -"
       description = "Login and change to root user"
       logging     = false
-    },
-    "tail-cw" = {
-      command     = "sudo tail -f /var/log/cloud-init-output.log"
-      description = "Tail the cloud-init-output logs"
-      logging     = true
+    }
   }
 }
 ```
 
 ## Variables
 
-| Name                    | Type                 | Description                                                              | Required | Default                                                                                                                                                   |
-| -----                   | -----                | -----                                                                    | -----    | -----                                                                                                                                                     |
-| `ssm_doc_map`           | **map(map(string))** | Map of data for SSM documents                                            | YES      | <pre>{<br> 'default' = {<br>  description = 'Login shell'<br>  command   = 'cd ; /bin/bash'<br>  logging   = true<br>  use_root  = true<br> },<br>}</pre> |
-| `session_timeout`       | **number**           | Amount of time (in minutes) of inactivity to allow before a session ends | YES      | 15                                                                                                                                                        |
-| `region`                | **string**           | AWS Region                                                               | YES      |                                                                                                                                                           |
-| `env_name`              | **string**           | Environment name                                                         | YES      |                                                                                                                                                           |
-| `bucket_name_prefix`    | **string**           | First substring in S3 bucket name                                        | YES      |                                                                                                                                                           |
-| `log_bucket_name`       | **string**           | Override name of the bucket used for S3 logging                          | NO       | <blank>                                                                                                                                                   |
-| `inventory_bucket_name` | **string**           | Override name of the S3 bucket used for S3 Inventory reports             | NO       | <blank>                                                                                                                                                   |
+| Name                    | Type                 | Description                                                              | Required | Default                                                                                                                             |
+| -----                   | -----                | -----                                                                    | -----    | -----                                                                                                                               |
+| `ssm_doc_map`           | **map(map(string))** | Map of data for SSM documents                                            | YES      | <pre>{<br> 'default' = {<br>  description = 'Login shell'<br>  command   = 'cd ; /bin/bash'<br>  logging   = true<br> },<br>}</pre> |
+| `session_timeout`       | **number**           | Amount of time (in minutes) of inactivity to allow before a session ends | YES      | 15                                                                                                                                  |
+| `region`                | **string**           | AWS Region                                                               | YES      |                                                                                                                                     |
+| `env_name`              | **string**           | Environment name                                                         | YES      |                                                                                                                                     |
+| `bucket_name_prefix`    | **string**           | First substring in S3 bucket name                                        | YES      |                                                                                                                                     |
+| `log_bucket_name`       | **string**           | Override name of the bucket used for S3 logging                          | NO       | <blank>                                                                                                                             |
+| `inventory_bucket_name` | **string**           | Override name of the S3 bucket used for S3 Inventory reports             | NO       | <blank>                                                                                                                             |

--- a/ssm/README.md
+++ b/ssm/README.md
@@ -1,6 +1,6 @@
 # `ssm`
 
-This Terraform module is used to create SSM Documents for connecting to and running commands on AWS EC2 instances. Along with the documents themselves, this module creates:
+This Terraform module is used to create `Standard_Session`, `Command`, and/or `InteractiveCommand` SSM Documents for connecting to and running commands on AWS EC2 instances. Along with the documents themselves, this module creates:
 
 1. An S3 bucket, and CloudWatch log group, for storing logs of SSM sessions (see note below) -- the S3 bucket is configured using [the `s3_config` module](https://github.com/18F/identity-terraform/tree/main/s3_config) from this repo
 2. A second CloudWatch log group for logging when, and by whom, any given SSM document is used (via a CloudWatch event rule)
@@ -11,15 +11,16 @@ This Terraform module is used to create SSM Documents for connecting to and runn
 
 ## Schema
 
-SSM documents are created from individual object blocks within the `ssm_doc_map` variable, e.g.:
+SSM documents are created from individual object blocks within the `ssm_*_map` variable, e.g.:
 
-```
+```hcl
     "sudo" = {
       command     = "sudo su -"
       description = "Login and change to root user"
       logging     = false
     },
 ```
+
 In this example:
 - The resulting SSM document will be named `<ENV>-ssm-document-sudo`
 - Starting a session using this document is done via `aws ssm start-session --document <ENV>-ssm-document-sudo`
@@ -73,12 +74,14 @@ module "ssm" {
 
 ## Variables
 
-| Name                    | Type                 | Description                                                              | Required | Default                                                                                                                             |
-| -----                   | -----                | -----                                                                    | -----    | -----                                                                                                                               |
-| `ssm_doc_map`           | **map(map(string))** | Map of data for SSM documents                                            | YES      | <pre>{<br> 'default' = {<br>  description = 'Login shell'<br>  command   = 'cd ; /bin/bash'<br>  logging   = true<br> },<br>}</pre> |
-| `session_timeout`       | **number**           | Amount of time (in minutes) of inactivity to allow before a session ends | YES      | 15                                                                                                                                  |
-| `region`                | **string**           | AWS Region                                                               | YES      |                                                                                                                                     |
-| `env_name`              | **string**           | Environment name                                                         | YES      |                                                                                                                                     |
-| `bucket_name_prefix`    | **string**           | First substring in S3 bucket name                                        | YES      |                                                                                                                                     |
-| `log_bucket_name`       | **string**           | Override name of the bucket used for S3 logging                          | NO       | <blank>                                                                                                                             |
-| `inventory_bucket_name` | **string**           | Override name of the S3 bucket used for S3 Inventory reports             | NO       | <blank>                                                                                                                             |
+| Name                    | Type                 | Description                                                              | Required | Default                                                                                                                                                     |
+| -----                   | -----                | -----                                                                    | -----    | -----                                                                                                                                                       |
+| `ssm_doc_map`           | **map(map(string))** | Map of data for SSM `Standard_Session` documents                         | YES      | <pre>{<br> "default" = {<br>  description = "Login shell"<br>  command   = "cd ; /bin/bash"<br>  logging   = true<br> },<br>}</pre>                         |
+| `ssm_cmd_doc_map`       | **map(any)**         | Map of data for SSM `Command` documents                                  | YES      | <pre>{<br> "default" = {<br>  description = "Verify host uptime"<br>  command   = ["uptime"]<br>  logging   = false<br>  parameters  = []<br> },<br>}</pre> |
+| `ssm_doc_map`           | **map(any)**         | Map of data for SSM `InteractiveCommand` documents                       | YES      | <pre>{<br> "default" = {<br>  description = "Check network interface configuration"<br>  command   = ["ifconfig"]<br>  parameters  = []<br> },<br>}</pre>   |
+| `session_timeout`       | **number**           | Amount of time (in minutes) of inactivity to allow before a session ends | YES      | 15                                                                                                                                                          |
+| `region`                | **string**           | AWS Region                                                               | YES      |                                                                                                                                                             |
+| `env_name`              | **string**           | Environment name                                                         | YES      |                                                                                                                                                             |
+| `bucket_name_prefix`    | **string**           | First substring in S3 bucket name                                        | YES      |                                                                                                                                                             |
+| `log_bucket_name`       | **string**           | Override name of the bucket used for S3 logging                          | NO       | <blank>                                                                                                                                                     |
+| `inventory_bucket_name` | **string**           | Override name of the S3 bucket used for S3 Inventory reports             | NO       | <blank>                                                                                                                                                     |

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -238,7 +238,7 @@ inputs:
   runAsEnabled: true
   runAsDefaultUser: ''
   shellProfile:
-    linux: 'trap "exit 0" 1 2 3 15 20; ${each.value["command"]} ; exit'
+    linux: 'trap exit 1 2 3 15 20; ${each.value["command"]} ; exit'
   DOC
 }
 

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -235,8 +235,8 @@ inputs:
   cloudWatchEncryptionEnabled: false%{endif}
   kmsKeyId: ${aws_kms_key.kms_ssm.arn}
   idleSessionTimeout: ${var.session_timeout}
-  %{if each.value["use_root"] == "false"}runAsEnabled: true
-  runAsDefaultUser: ''%{endif}
+  runAsEnabled: true
+  runAsDefaultUser: ''
   shellProfile:
     linux: 'trap "exit 0" INT TERM; ${each.value["command"]} ; exit'
   DOC

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -238,7 +238,7 @@ inputs:
   %{if each.value["use_root"] == "false"}runAsEnabled: true
   runAsDefaultUser: ''%{endif}
   shellProfile:
-    linux: 'trap exit INT TERM; ${each.value["command"]}%{if each.value["exit"]}; exit%{endif}'
+    linux: 'trap "exit 0" INT TERM; ${each.value["command"]} ; exit'
   DOC
 }
 
@@ -272,9 +272,42 @@ mainSteps:
   DOC
 }
 
+# SSM InteractiveCommands Session Docs
+resource "aws_ssm_document" "ssm_interactive_cmd" {
+  for_each = var.ssm_interactive_cmd_map
+  lifecycle { create_before_destroy = false }
+  name            = "${var.env_name}-ssm-document-${each.key}"
+  document_type   = "Session"
+  target_type     = "/AWS::EC2::Instance"
+  document_format = "YAML"
+  content         = <<DOC
+---
+schemaVersion: '1.0'
+description: ${each.value["description"]}
+sessionType: InteractiveCommands
+inputs:
+  s3EncryptionEnabled: false
+  cloudWatchEncryptionEnabled: false
+  kmsKeyId: ${aws_kms_key.kms_ssm.arn}
+  idleSessionTimeout: ${var.session_timeout}
+  parameters:
+    %{for ssm_parameter in each.value["parameters"]}
+    ${ssm_parameter.name}:
+      type: ${ssm_parameter.type}
+      default: ${ssm_parameter.default}
+      description: ${ssm_parameter.description}
+      %{if ssm_parameter.pattern}allowedPattern: ${ssm_parameter.pattern}%{endif}
+    %{endfor}
+  properties:
+    linux:
+      commands: ${each.value["command"]}
+      runAsElevated: true
+  DOC
+}
+
 # log when SSM commands are used, even if session data is not
 resource "aws_cloudwatch_event_rule" "ssm_cmd" {
-  for_each = var.ssm_doc_map
+  for_each = local.all_docs_and_cmds
 
   name        = "${var.env_name}-ssm-cmd-${each.key}"
   description = "Capture when SSM command '${each.key}' used in ${var.env_name}"
@@ -313,7 +346,7 @@ resource "aws_cloudwatch_log_group" "ssm_cmd_logs" {
 }
 
 resource "aws_cloudwatch_event_target" "ssm_cmds" {
-  for_each = var.ssm_doc_map
+  for_each = local.all_docs_and_cmds
 
   rule      = aws_cloudwatch_event_rule.ssm_cmd[each.key].name
   target_id = "${var.env_name}_SSMCmd_${each.key}"

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -296,7 +296,7 @@ inputs:
       type: ${ssm_parameter.type}
       default: ${ssm_parameter.default}
       description: ${ssm_parameter.description}
-      %{if ssm_parameter.pattern}allowedPattern: ${ssm_parameter.pattern}%{endif}
+      allowedPattern: ${ssm_parameter.pattern}
     %{endfor}
   properties:
     linux:

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -238,7 +238,7 @@ inputs:
   %{if each.value["use_root"] == "false"}runAsEnabled: true
   runAsDefaultUser: ''%{endif}
   shellProfile:
-    linux: 'trap "exit 0" INT TERM; ${each.value["command"]} ; exit'
+    linux: 'trap exit INT TERM; ${each.value["command"]}%{if each.value["exit"]}; exit%{endif}'
   DOC
 }
 

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -238,7 +238,7 @@ inputs:
   runAsEnabled: true
   runAsDefaultUser: ''
   shellProfile:
-    linux: 'trap "exit 0" INT TERM; ${each.value["command"]} ; exit'
+    linux: 'trap "exit 0" 1 2 3 15 20; ${each.value["command"]} ; exit'
   DOC
 }
 
@@ -291,16 +291,16 @@ inputs:
   kmsKeyId: ${aws_kms_key.kms_ssm.arn}
   idleSessionTimeout: ${var.session_timeout}
 parameters:
-%{for ssm_parameter in each.value["parameters"]}
-${ssm_parameter.name}:
-  type: ${ssm_parameter.type}
-  default: ${ssm_parameter.default}
-  description: ${ssm_parameter.description}
-  allowedPattern: ${ssm_parameter.pattern}
-%{endfor}
+  %{for ssm_parameter in each.value["parameters"]}
+  ${ssm_parameter.name}:
+    type: ${ssm_parameter.type}
+    default: ${ssm_parameter.default}
+    description: ${ssm_parameter.description}
+    allowedPattern: ${ssm_parameter.pattern}
+  %{endfor}
 properties:
   linux:
-    commands: ${each.value["command"]}
+    %{for ssm_cmd in each.value["command"]}commands: "${ssm_cmd}"%{endfor}
     runAsElevated: true
   DOC
 }

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -238,7 +238,7 @@ inputs:
   runAsEnabled: true
   runAsDefaultUser: ''
   shellProfile:
-    linux: 'trap exit 1 2 3 15 20; ${each.value["command"]} ; exit'
+    linux: 'trap "exit 0" INT TERM; ${each.value["command"]} ; exit'
   DOC
 }
 

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -290,18 +290,18 @@ inputs:
   cloudWatchEncryptionEnabled: false
   kmsKeyId: ${aws_kms_key.kms_ssm.arn}
   idleSessionTimeout: ${var.session_timeout}
-  parameters:
-    %{for ssm_parameter in each.value["parameters"]}
-    ${ssm_parameter.name}:
-      type: ${ssm_parameter.type}
-      default: ${ssm_parameter.default}
-      description: ${ssm_parameter.description}
-      allowedPattern: ${ssm_parameter.pattern}
-    %{endfor}
-  properties:
-    linux:
-      commands: ${each.value["command"]}
-      runAsElevated: true
+parameters:
+%{for ssm_parameter in each.value["parameters"]}
+${ssm_parameter.name}:
+  type: ${ssm_parameter.type}
+  default: ${ssm_parameter.default}
+  description: ${ssm_parameter.description}
+  allowedPattern: ${ssm_parameter.pattern}
+%{endfor}
+properties:
+  linux:
+    commands: ${each.value["command"]}
+    runAsElevated: true
   DOC
 }
 

--- a/ssm/outputs.tf
+++ b/ssm/outputs.tf
@@ -12,18 +12,3 @@ output "ssm_cmd_logs" {
   description = "Name of the CloudWatch Log Group for SSM command logging."
   value       = aws_cloudwatch_log_group.ssm_cmd_logs.name
 }
-
-output "ssm_kms_key_id" {
-  description = "ID of the KMS key used for encryption of S3/CloudWatch logs."
-  value       = aws_kms_key.kms_ssm.id
-}
-
-output "ssm_kms_key_arn" {
-  description = "ARN of the KMS key used for encryption of S3/CloudWatch logs."
-  value       = aws_kms_key.kms_ssm.arn
-}
-
-output "ssm_kms_alias" {
-  description = "Alias of the KMS key used for encryption of S3/CloudWatch logs."
-  value       = aws_kms_alias.kms_ssm.name
-}

--- a/ssm/outputs.tf
+++ b/ssm/outputs.tf
@@ -12,3 +12,18 @@ output "ssm_cmd_logs" {
   description = "Name of the CloudWatch Log Group for SSM command logging."
   value       = aws_cloudwatch_log_group.ssm_cmd_logs.name
 }
+
+output "ssm_kms_key_id" {
+  description = "ID of the KMS key used for encryption of S3/CloudWatch logs."
+  value       = aws_kms_key.kms_ssm.id
+}
+
+output "ssm_kms_key_arn" {
+  description = "ARN of the KMS key used for encryption of S3/CloudWatch logs."
+  value       = aws_kms_key.kms_ssm.arn
+}
+
+output "ssm_kms_alias" {
+  description = "Alias of the KMS key used for encryption of S3/CloudWatch logs."
+  value       = aws_kms_alias.kms_ssm.name
+}

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -35,6 +35,22 @@ EOM
   }
 }
 
+variable "ssm_interactive_cmd_map" {
+  description = <<EOM
+REQUIRED. Map of data for SSM InteractiveCommand Session Documents. Each must
+include the document name, description, command to run, and any parameter(s) used
+to configure said command.
+EOM
+  type        = map(any)
+  default = {
+    "default" = {
+      description = "Check network interface configuration"
+      command     = ["ifconfig"]
+      parameters  = []
+    },
+  }
+}
+
 variable "session_timeout" {
   description = <<EOM
 REQUIRED. Amount of time (in minutes) of inactivity
@@ -93,4 +109,10 @@ locals {
   inventory_bucket = var.inventory_bucket_name != "" ? var.inventory_bucket_name : join(".",
     [var.bucket_name_prefix, "s3-inventory", local.bucket_name_suffix]
   )
+
+  all_docs_and_cmds = toset(compact(flatten([
+    keys(var.ssm_doc_map),
+    keys(var.ssm_interactive_cmd_map),
+    keys(var.ssm_cmd_doc_map)
+  ])))
 }

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -1,9 +1,8 @@
 variable "ssm_doc_map" {
   description = <<EOM
-REQUIRED. Map of data for SSM Documents. Each must include the document name,
-description, command(s) to run at login, whether to log the commands/output from the
-given session/document, whether to run specifically as root (vs. a Linux user),
-and whether or not to exit once the command is complete.
+REQUIRED. Map of data for SSM Session Documents. Each must include the document name,
+description, command(s) to run at login, and whether to log the commands/output
+from the given session/document.
 EOM
   type        = map(map(string))
   default = {
@@ -11,7 +10,6 @@ EOM
       description = "Login shell"
       command     = "cd ; /bin/bash"
       logging     = false
-      use_root    = false
       exit        = true
     },
   }
@@ -19,9 +17,9 @@ EOM
 
 variable "ssm_cmd_doc_map" {
   description = <<EOM
-REQUIRED. Map of data for SSM Documents. Each must include the document name,
-description, command(s) to run at login, whether to log the commands/output from the
-given session/document, and whether to run specifically as root (vs. a Linux user).
+REQUIRED. Map of data for SSM Command Documents. Each must include the document name,
+description, command to run, any parameter(s) used to configure said command, and
+whether to log the commands/output from the given session/document.
 EOM
   type        = map(any)
   default = {
@@ -29,7 +27,6 @@ EOM
       description = "Login shell"
       command     = ["uptime"]
       logging     = false
-      use_root    = false
       parameters  = []
     },
   }

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -2,7 +2,8 @@ variable "ssm_doc_map" {
   description = <<EOM
 REQUIRED. Map of data for SSM Documents. Each must include the document name,
 description, command(s) to run at login, whether to log the commands/output from the
-given session/document, and whether to run specifically as root (vs. a Linux user).
+given session/document, whether to run specifically as root (vs. a Linux user),
+and whether or not to exit once the command is complete.
 EOM
   type        = map(map(string))
   default = {
@@ -11,6 +12,7 @@ EOM
       command     = "cd ; /bin/bash"
       logging     = false
       use_root    = false
+      exit        = true
     },
   }
 }

--- a/ssm/variables.tf
+++ b/ssm/variables.tf
@@ -24,7 +24,7 @@ EOM
   type        = map(any)
   default = {
     "default" = {
-      description = "Login shell"
+      description = "Verify host uptime"
       command     = ["uptime"]
       logging     = false
       parameters  = []


### PR DESCRIPTION
# tl;dr

- Adds a new resource, `aws_ssm_document.ssm_interactive_cmd`, which creates `Session/InteractiveCommands` SSM documents based on the resource template (used for running single interactive commands with/without parameters)
- Removes `use_root` parameter from `aws_ssm_document.ssm_session` resources, since `aws_ssm_document.ssm_interactive_cmd` resources will run with elevated privileges (negating the need for a `root`-only `Standard_Session`)
- Updates the `aws_cloudwatch_event_rule.ssm_cmd` and `aws_cloudwatch_event_target.ssm_cmds` resources so that CloudWatch Events and Targets are created for ***all*** SSM documents created in this module, ensuring that all invocations of any SSM document are all fully logged in CloudWatch
- Updates the README and variable descriptions to be up-to-date with current and recent updates