### PR TITLE
Build an SLI dashboard

### DIFF
--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -126,8 +126,6 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_windowed_slo" {
 }
 
 resource "aws_cloudwatch_dashboard" "sli" {
-  for_each = var.slis
-
   dashboard_name = "${var.env_name}-sli"
   dashboard_body = jsonencode({
     "widgets" : [for k, v in var.slis :

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -143,6 +143,11 @@ resource "aws_cloudwatch_dashboard" "sli" {
           "title" : "${v.description != null ? v.description : k} over last ${var.window_days} days"
           "stat": "Average"
           "period" : 24 * 60 * 60
+          "yAxis": {
+            "left": {
+              "showUnits": false
+            }
+          }
         }
       }
     ]

--- a/slo_lambda/variables.tf
+++ b/slo_lambda/variables.tf
@@ -46,21 +46,22 @@ variable "sli_prefix" {
 }
 
 variable "slis" {
-  description = "JSON serialization of SLIs"
-  type        = map(object({
+  description = "SLI configuration"
+  type = map(object({
+    description = optional(string)
     window_days = optional(number)
     numerator = list(object({
-      namespace = string
-      metric_name = string
-      dimensions = list(map(string))
-      statistic = optional(string)
+      namespace          = string
+      metric_name        = string
+      dimensions         = list(map(string))
+      statistic          = optional(string)
       extended_statistic = optional(string)
     }))
     denominator = list(object({
-      namespace = string
-      metric_name = string
-      dimensions = list(map(string))
-      statistic = optional(string)
+      namespace          = string
+      metric_name        = string
+      dimensions         = list(map(string))
+      statistic          = optional(string)
       extended_statistic = optional(string)
     }))
   }))


### PR DESCRIPTION
Example: 
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/55769/227375321-8ddb9e9f-401b-496c-8ce4-55b33113dcc9.png">


Corresponds to https://github.com/18F/identity-devops/pull/6005

<details>
<summary>Terraform will perform the following actions [in prod.]</summary>

```
  # module.cloudwatch_sli.aws_cloudwatch_dashboard.sli will be created
  + resource "aws_cloudwatch_dashboard" "sli" {
      + dashboard_arn  = (known after apply)
      + dashboard_body = jsonencode(
            {
              + widgets = [
                  + {
                      + height     = 9
                      + properties = {
                          + metrics = [
                              + [
                                  + "prod/sli",
                                  + "idp-all_availability",
                                ],
                            ]
                          + period  = 86400
                          + region  = "us-west-2"
                          + stacked = false
                          + stat    = "Average"
                          + title   = "all_availability over last 28 days"
                          + view    = "timeSeries"
                        }
                      + type       = "metric"
                      + width      = 24
                    },
                  + {
                      + height     = 9
                      + properties = {
                          + metrics = [
                              + [
                                  + "prod/sli",
                                  + "idp-interesting_availability",
                                ],
                            ]
                          + period  = 86400
                          + region  = "us-west-2"
                          + stacked = false
                          + stat    = "Average"
                          + title   = "Ratio of successful \"interesting\" requests over last 28 days"
                          + view    = "timeSeries"
                        }
                      + type       = "metric"
                      + width      = 24
                    },
                  + {
                      + height     = 9
                      + properties = {
                          + metrics = [
                              + [
                                  + "prod/sli",
                                  + "idp-interesting_latency",
                                ],
                            ]
                          + period  = 86400
                          + region  = "us-west-2"
                          + stacked = false
                          + stat    = "Average"
                          + title   = "Ratio of responses < 0.1s over last 28 days"
                          + view    = "timeSeries"
                        }
                      + type       = "metric"
                      + width      = 24
                    },
                ]
            }
        )
      + dashboard_name = "prod-sli"
      + id             = (known after apply)
    }

  # module.cloudwatch_sli.aws_lambda_function.windowed_slo will be updated in-place
  ~ resource "aws_lambda_function" "windowed_slo" {
        id                             = "prod-cloudwatch-sli"
      ~ last_modified                  = "2023-02-16T17:18:36.000+0000" -> (known after apply)
      + skip_destroy                   = false
      ~ source_code_hash               = "EetTwlPy2wHqUlZQTRKK/tyACDR++b9v3AugFIrwcXk=" -> "DPuQnZVGAOI0v414X76857Car90L+SfTt3TGTkz+jJs="
        tags                           = {}
        # (20 unchanged attributes hidden)

      ~ environment {
          ~ variables = {
              ~ "SLIS"              = jsonencode(
                  ~ {
                      ~ all_availability         = {
                          + description = null
                            # (3 unchanged elements hidden)
                        }
                      ~ interesting_availability = {
                          + description = "Ratio of successful \"interesting\" requests"
                            # (3 unchanged elements hidden)
                        }
                      ~ interesting_latency      = {
                          + description = "Ratio of responses < 0.1s"
                            # (3 unchanged elements hidden)
                        }
                    }
                )
                # (4 unchanged elements hidden)
            }
        }

        # (2 unchanged blocks hidden)
    }
```
</details>
