### PR TITLE
use var.zero_size for custom autozero spindown capacity

### DIFF
--- a/asg_recycle/main.tf
+++ b/asg_recycle/main.tf
@@ -37,10 +37,10 @@ resource "aws_autoscaling_schedule" "recycle_spindown" {
   autoscaling_group_name = var.asg_name
 }
 
-# Spin down to 0 hosts, on a regular schedule. Depending upon selection,
+# Spin down to var.zero_size hosts, on a regular schedule. Depending upon selection,
 # do this either daily after working hours, weekly (same time), or nightly.
 # Follow a similar schedule to the recycle one above.
-# Ensure that ASG can spin down/up, instead of capping min/max at 0 hosts.
+# Ensure that ASG can spin down/up, instead of capping min/max at var.zero_size hosts.
 
 resource "aws_autoscaling_schedule" "autozero_spinup" {
   for_each = toset(local.schedule["autozero_up"])
@@ -50,8 +50,8 @@ resource "aws_autoscaling_schedule" "autozero_spinup" {
     index(local.schedule["autozero_up"], each.key)
   ])
   min_size = var.normal_min
-  max_size = var.normal_max == 0 ? (
-  var.normal_min == 0 ? 1 : var.normal_min) : var.normal_max
+  max_size = var.normal_max == var.zero_size ? (
+  var.normal_min == var.zero_size ? 1 : var.normal_min) : var.normal_max
   desired_capacity = (
     var.normal_desired > var.normal_max || var.normal_desired < var.normal_min ? (
     var.normal_max) : var.normal_desired
@@ -68,9 +68,9 @@ resource "aws_autoscaling_schedule" "autozero_spindown" {
     "auto-zero.spindown",
     index(local.schedule["autozero_down"], each.key)
   ])
-  min_size               = 0
+  min_size               = var.zero_size
   max_size               = var.max_size
-  desired_capacity       = 0
+  desired_capacity       = var.zero_size
   recurrence             = each.key
   time_zone              = var.time_zone
   autoscaling_group_name = var.asg_name

--- a/asg_recycle/variables.tf
+++ b/asg_recycle/variables.tf
@@ -24,6 +24,12 @@ variable "min_size" {
   default     = -1
 }
 
+variable "zero_size" {
+  description = "Desired capacity to spin down to with the autozero schedules."
+  type        = number
+  default     = 0
+}
+
 variable "normal_desired" {
   description = <<EOM
 Default Desired capacity for the Auto Scaling Group.

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -141,11 +141,11 @@ resource "aws_cloudwatch_dashboard" "sli" {
           ]
           "region" : data.aws_region.current.name
           "title" : "${v.description != null ? v.description : k} over last ${var.window_days} days"
-          "stat": "Average"
+          "stat" : "Average"
           "period" : 24 * 60 * 60
-          "yAxis": {
-            "left": {
-              "showUnits": false
+          "yAxis" : {
+            "left" : {
+              "showUnits" : false
             }
           }
         }

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -214,8 +214,8 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 }
 
 module "s3_config" {
-  for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
+  for_each = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
+  source   = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
   depends_on = [aws_s3_bucket.s3-access-logs]
 


### PR DESCRIPTION
Does what it says on the tin!

Instead of spinning down to 0 hosts with the `autozero` schedules, spin down to `var.zero_size` instead (which defaults to 0). Useful for situations where, while most ASGs/environments can spin down to 0 hosts on a regular basis, one or more should only go down to 1 (i.e. use a different variable to set `var.zero_size` for each ASG/env).