### PR TITLE
add BucketOwnerPreferred ownership controls to buckets w/ aws_s3_bucket_acl resources

### DIFF
--- a/elb_access_logs_bucket/main.tf
+++ b/elb_access_logs_bucket/main.tf
@@ -62,9 +62,19 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "logs" {
   bucket = aws_s3_bucket.logs.id
   acl    = "log-delivery-write"
+
+  depends_on = [aws_s3_bucket_ownership_controls.logs]
 }
 
 resource "aws_s3_bucket_policy" "logs" {

--- a/git2s3_artifacts/main.tf
+++ b/git2s3_artifacts/main.tf
@@ -91,10 +91,21 @@ resource "aws_s3_bucket" "artifact_bucket" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "artifact_bucket" {
+  bucket = aws_s3_bucket.artifact_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "artifact_bucket" {
   bucket = aws_s3_bucket.artifact_bucket.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.artifact_bucket]
 }
+
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "artifact_bucket" {
   bucket = aws_s3_bucket.artifact_bucket.id

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -206,11 +206,6 @@ resource "aws_s3_bucket" "guardduty" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "guardduty" {
-  bucket = aws_s3_bucket.guardduty.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_ownership_controls" "guardduty" {
   bucket = aws_s3_bucket.guardduty.id
 

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -211,6 +211,21 @@ resource "aws_s3_bucket_acl" "guardduty" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_ownership_controls" "guardduty" {
+  bucket = aws_s3_bucket.guardduty.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "guardduty" {
+  bucket = aws_s3_bucket.guardduty.id
+  acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.guardduty]
+}
+
 resource "aws_s3_bucket_policy" "guardduty" {
   bucket = aws_s3_bucket.guardduty.id
   policy = data.aws_iam_policy_document.guardduty_s3.json

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -58,7 +58,7 @@ resource "aws_s3_bucket_acl" "bucket" {
   bucket   = aws_s3_bucket.bucket[each.key]
   acl      = lookup(each.value, "acl", "private")
 
-  depends_on = [aws_s3_bucket_ownership_controls.bucket[each.key]]
+  depends_on = [aws_s3_bucket_ownership_controls.bucket]
 }
 
 resource "aws_s3_bucket_policy" "bucket" {

--- a/s3_bucket_block/main.tf
+++ b/s3_bucket_block/main.tf
@@ -44,10 +44,21 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = lookup(each.value, "force_destroy", true)
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket" {
+  for_each = var.bucket_data
+  bucket   = aws_s3_bucket.bucket[each.key]
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "bucket" {
   for_each = var.bucket_data
   bucket   = aws_s3_bucket.bucket[each.key]
   acl      = lookup(each.value, "acl", "private")
+
+  depends_on = [aws_s3_bucket_ownership_controls.bucket[each.key]]
 }
 
 resource "aws_s3_bucket_policy" "bucket" {

--- a/slo_lambda/main.tf
+++ b/slo_lambda/main.tf
@@ -141,11 +141,11 @@ resource "aws_cloudwatch_dashboard" "sli" {
           ]
           "region" : data.aws_region.current.name
           "title" : "${v.description != null ? v.description : k} over last ${var.window_days} days"
-          "stat": "Average"
+          "stat" : "Average"
           "period" : 24 * 60 * 60
-          "yAxis": {
-            "left": {
-              "showUnits": false
+          "yAxis" : {
+            "left" : {
+              "showUnits" : false
             }
           }
         }

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -102,9 +102,19 @@ resource "aws_s3_bucket_versioning" "ssm_logs" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "ssm_logs" {
+  bucket = aws_s3_bucket.ssm_logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "ssm_logs" {
   bucket = aws_s3_bucket.ssm_logs.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.ssm_logs]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "ssm_logs" {

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -178,7 +178,7 @@ resource "aws_s3_bucket_acl" "tf-state" {
   bucket = data.aws_s3_bucket.tf-state[count.index].id
   acl    = "private"
 
-  depends_on = [aws_s3_bucket_ownership_controls.tf-state[count.index]]
+  depends_on = [aws_s3_bucket_ownership_controls.tf-state]
 }
 
 resource "aws_s3_bucket_logging" "tf-state" {

--- a/state_bucket/main.tf
+++ b/state_bucket/main.tf
@@ -97,9 +97,19 @@ resource "aws_s3_bucket_versioning" "s3-access-logs" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "s3-access-logs" {
+  bucket = aws_s3_bucket.s3-access-logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "s3-access-logs" {
   bucket = aws_s3_bucket.s3-access-logs.id
   acl    = "log-delivery-write"
+
+  depends_on = [aws_s3_bucket_ownership_controls.s3-access-logs]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3-access-logs" {
@@ -154,10 +164,21 @@ resource "aws_s3_bucket_versioning" "tf-state" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "tf-state" {
+  count  = var.remote_state_enabled
+  bucket = data.aws_s3_bucket.tf-state[count.index].id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "tf-state" {
   count  = var.remote_state_enabled
   bucket = data.aws_s3_bucket.tf-state[count.index].id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.tf-state[count.index]]
 }
 
 resource "aws_s3_bucket_logging" "tf-state" {
@@ -214,8 +235,8 @@ resource "aws_s3_bucket_public_access_block" "inventory" {
 }
 
 module "s3_config" {
-  for_each   = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
-  source     = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
+  for_each = var.remote_state_enabled == 1 ? toset(["s3-access-logs", "tf-state"]) : toset(["s3-access-logs"])
+  source   = "github.com/18F/identity-terraform//s3_config?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
   #source = "../s3_config"
   depends_on = [aws_s3_bucket.s3-access-logs]
 


### PR DESCRIPTION
As [announced by AWS](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/), Amazon S3 is disabling S3 access control lists (ACLs) for all new S3 buckets. As a result, using the `aws_s3_bucket_acl` resource to create an ACL for a bucket -- one which does not already have ownership controls in place -- will fail, unless bucket ownership has already been configured:

```terraform
│ Error: error creating S3 bucket ACL for <BUCKET-NAME-HERE>: AccessControlListNotSupported: The bucket does not allow ACLs
│ 
│   with aws_s3_bucket_acl.example_bucket,
│   on s3.tf line 8, in resource "aws_s3_bucket_acl" "example_bucket":
│    8: resource "aws_s3_bucket_acl" "example_bucket" {
```

Per the [recommendation in the Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws/issues/28353), this PR adds an `aws_s3_bucket_ownership_controls` resource (set to `BucketOwnerPreferred`) for every bucket in this repo that also has an `aws_s3_bucket_acl` resource, and waits until the ownership controls have been set (via `depends_on`) before creating the ACL.