### PR TITLE
Use jsonencode() for string interpolation of commands

### DIFF
--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -275,10 +275,7 @@ mainSteps:
 - action: "aws:runShellScript"
   name: "block1"
   inputs:
-    runCommand:
-  %{for ssm_cmd in each.value["command"]~}
-  - ${ssm_cmd}
-  %{endfor}
+    runCommand: ${jsonencode(each.value["command"])}
   DOC
 }
 

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -257,29 +257,33 @@ resource "aws_ssm_document" "ssm_cmd" {
   for_each = var.ssm_cmd_doc_map
   lifecycle { create_before_destroy = false }
 
+  locals {
+    doc_parameters = [
+      for ssm_parameter in each.value["parameters"] : {
+        "type": ssm_parameter.type,
+        "default": ssm_parameter.default,
+        "description": ssm_parameter.description
+      }
+    ]
+  }
+
   name            = "${var.env_name}-ssm-cmd-${each.key}"
   document_type   = "Command"
   document_format = "YAML"
-  content         = <<DOC
----
-schemaVersion: "2.2"
-description: "${each.value["description"]}"
-parameters:
-  %{for ssm_parameter in each.value["parameters"]}
-  ${ssm_parameter.name}:
-    type: ${ssm_parameter.type}
-    default: ${ssm_parameter.default}
-    description: ${ssm_parameter.description}
-  %{endfor}
-mainSteps:
-- action: "aws:runShellScript"
-  name: "block1"
-  inputs:
-    runCommand:
-  %{for ssm_cmd in each.value["command"]~}
-  - ${ssm_cmd}
-  %{endfor}
-  DOC
+  content         = yamlencode(
+    "schemaVersion": "2.2",
+    "description": each.value["description"],
+    "parameters": local.doc_parameters,
+    "mainSteps": [
+      {
+        "action": "aws:runShellScript",
+        "name": "block1",
+        "inputs": {
+          "runCommand": each.value["command"]
+        }
+      }
+    ]
+  )
 }
 
 # SSM InteractiveCommands Session Docs

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -265,9 +265,9 @@ resource "aws_ssm_document" "ssm_cmd" {
     description   = each.value["description"],
     parameters = [
       for ssm_parameter in each.value["parameters"] : {
-        type        = ssm_parameter.type,
-        default     = ssm_parameter.default,
-        description = ssm_parameter.description
+        type        = "${ssm_parameter.type}",
+        default     = "${ssm_parameter.default}",
+        description = "${ssm_parameter.description}"
       }
     ],
     mainSteps = [

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -257,23 +257,19 @@ resource "aws_ssm_document" "ssm_cmd" {
   for_each = var.ssm_cmd_doc_map
   lifecycle { create_before_destroy = false }
 
-  locals {
-    doc_parameters = [
-      for ssm_parameter in each.value["parameters"] : {
-        "type" : ssm_parameter.type,
-        "default" : ssm_parameter.default,
-        "description" : ssm_parameter.description
-      }
-    ]
-  }
-
   name            = "${var.env_name}-ssm-cmd-${each.key}"
   document_type   = "Command"
   document_format = "YAML"
   content = yamlencode({
     "schemaVersion" : "2.2",
     "description" : each.value["description"],
-    "parameters" : local.doc_parameters,
+    "parameters" : [
+      for ssm_parameter in each.value["parameters"] : {
+        "type" : ssm_parameter.type,
+        "default" : ssm_parameter.default,
+        "description" : ssm_parameter.description
+      }
+    ],
     "mainSteps" : [
       {
         "action" : "aws:runShellScript",

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -261,21 +261,21 @@ resource "aws_ssm_document" "ssm_cmd" {
   document_type   = "Command"
   document_format = "YAML"
   content = yamlencode({
-    "schemaVersion" : "2.2",
-    "description" : each.value["description"],
-    "parameters" : [
+    schemaVersion = "2.2",
+    description   = each.value["description"],
+    parameters = [
       for ssm_parameter in each.value["parameters"] : {
-        "type" : ssm_parameter.type,
-        "default" : ssm_parameter.default,
-        "description" : ssm_parameter.description
+        type        = ssm_parameter.type,
+        default     = ssm_parameter.default,
+        description = ssm_parameter.description
       }
     ],
-    "mainSteps" : [
+    mainSteps = [
       {
-        "action" : "aws:runShellScript",
-        "name" : "block1",
-        "inputs" : {
-          "runCommand" : each.value["command"]
+        action = "aws:runShellScript",
+        name   = "block1",
+        inputs = {
+          runCommand = each.value["command"]
         }
       }
     ]

--- a/ssm/main.tf
+++ b/ssm/main.tf
@@ -260,9 +260,9 @@ resource "aws_ssm_document" "ssm_cmd" {
   locals {
     doc_parameters = [
       for ssm_parameter in each.value["parameters"] : {
-        "type": ssm_parameter.type,
-        "default": ssm_parameter.default,
-        "description": ssm_parameter.description
+        "type" : ssm_parameter.type,
+        "default" : ssm_parameter.default,
+        "description" : ssm_parameter.description
       }
     ]
   }
@@ -270,20 +270,20 @@ resource "aws_ssm_document" "ssm_cmd" {
   name            = "${var.env_name}-ssm-cmd-${each.key}"
   document_type   = "Command"
   document_format = "YAML"
-  content         = yamlencode(
-    "schemaVersion": "2.2",
-    "description": each.value["description"],
-    "parameters": local.doc_parameters,
-    "mainSteps": [
+  content = yamlencode({
+    "schemaVersion" : "2.2",
+    "description" : each.value["description"],
+    "parameters" : local.doc_parameters,
+    "mainSteps" : [
       {
-        "action": "aws:runShellScript",
-        "name": "block1",
-        "inputs": {
-          "runCommand": each.value["command"]
+        "action" : "aws:runShellScript",
+        "name" : "block1",
+        "inputs" : {
+          "runCommand" : each.value["command"]
         }
       }
     ]
-  )
+  })
 }
 
 # SSM InteractiveCommands Session Docs


### PR DESCRIPTION
Allows proper escaping of multi-line strings, and commands with special YAML characters in it

~Uses [`yamlencode`](https://developer.hashicorp.com/terraform/language/functions/yamlencode), which is stable as of 1.4, but for earlier versions they recommend `jsonencode` instead~

~**Note**: I haven't tested this because I'm not 100% sure how to, also my Terraform syntax highlighting did not like the nested dictionaries, so that may not be possible~

This works because JSON is valid YAML