### PR TITLE
Multi-Region Provider Fixes

### DIFF
--- a/dnssec/main.tf
+++ b/dnssec/main.tf
@@ -2,11 +2,6 @@
 
 # -- Data Sources --
 
-provider "aws" {
-  alias  = "use1"
-  region = "us-east-1"
-}
-
 data "aws_caller_identity" "current" {
 }
 
@@ -104,7 +99,6 @@ locals {
 
 resource "aws_kms_key" "dnssec" {
   for_each = var.dnssec_ksks
-  provider = aws.use1
 
   customer_master_key_spec = "ECC_NIST_P256"
   deletion_window_in_days  = 7
@@ -126,7 +120,6 @@ resource "aws_kms_key" "dnssec" {
 
 resource "aws_kms_alias" "dnssec" {
   for_each = var.dnssec_ksks
-  provider = aws.use1
 
   name          = "alias/${replace(var.dnssec_zone_name, "/\\./", "_")}-ksk-${each.key}"
   target_key_id = aws_kms_key.dnssec[each.key].key_id

--- a/dnssec/versions.tf
+++ b/dnssec/versions.tf
@@ -1,1 +1,0 @@
-../versions.tf

--- a/dnssec/versions.tf
+++ b/dnssec/versions.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [ aws.use1 ]
+    }
+    archive = {
+      source = "hashicorp/archive"
+    }
+    cloudinit = {
+      source = "hashicorp/cloudinit"
+    }
+    external = {
+      source = "hashicorp/external"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    github = {
+      source = "integrations/github"
+    }
+    newrelic = {
+      source = "newrelic/newrelic"
+    }
+  }
+  required_version = ">= 1.3.5"
+}


### PR DESCRIPTION
 - Removes the custom AWS provider definition used for DNSSEC in favor of one defined in the parent module