### PR TITLE
add ssm_kms_arn output to ssm module

### DIFF
--- a/ssm/outputs.tf
+++ b/ssm/outputs.tf
@@ -12,3 +12,8 @@ output "ssm_cmd_logs" {
   description = "Name of the CloudWatch Log Group for SSM command logging."
   value       = aws_cloudwatch_log_group.ssm_cmd_logs.name
 }
+
+output "ssm_kms_arn" {
+  description = "ARN of the KMS key used for S3/session/log encryption."
+  value       = aws_kms_key.kms_ssm.arn
+}


### PR DESCRIPTION
Does what it says on the tin! Useful in situations where we need to reference the ARN of the KMS key created within this module.