### PR TITLE
Updating KMS Matching to Ruby 3.2 Runtimes

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -788,7 +788,7 @@ resource "aws_lambda_function" "cloudtrail_processor" {
   description   = "KMS CT Log Processor"
   role          = aws_iam_role.cloudtrail_processor.arn
   handler       = "main.IdentityKMSMonitor::CloudTrailToDynamoHandler.process"
-  runtime       = "ruby2.7"
+  runtime       = "ruby3.2"
   timeout       = 120 # seconds
 
   environment {
@@ -969,7 +969,7 @@ resource "aws_lambda_function" "cloudwatch_processor" {
   description   = "KMS CW Log Processor"
   role          = aws_iam_role.cloudwatch_processor.arn
   handler       = "main.IdentityKMSMonitor::CloudWatchKMSHandler.process"
-  runtime       = "ruby2.7"
+  runtime       = "ruby3.2"
   timeout       = 120 # seconds
 
   environment {
@@ -1103,7 +1103,7 @@ resource "aws_lambda_function" "event_processor" {
   description   = "KMS Log Event Processor"
   role          = aws_iam_role.event_processor.arn
   handler       = "main.IdentityKMSMonitor::CloudWatchEventGenerator.process"
-  runtime       = "ruby2.7"
+  runtime       = "ruby3.2"
   timeout       = 120 # seconds
 
   environment {

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -20,6 +20,10 @@ locals {
 data "aws_caller_identity" "current" {
 }
 
+data "local_file" "lambda_processor_zip_file" {
+  filename = var.lambda_kms_cw_processor_zip
+}
+
 data "aws_iam_policy_document" "kms" {
   # Allow root users in
   statement {
@@ -791,6 +795,10 @@ resource "aws_lambda_function" "cloudtrail_processor" {
   runtime       = "ruby3.2"
   timeout       = 120 # seconds
 
+  lifecycle {
+    replace_triggered_by = [data.local_file.lambda_processor_zip_file.id]
+  }
+
   environment {
     variables = {
       DEBUG               = var.kmslog_lambda_debug ? "1" : ""
@@ -972,6 +980,10 @@ resource "aws_lambda_function" "cloudwatch_processor" {
   runtime       = "ruby3.2"
   timeout       = 120 # seconds
 
+  lifecycle {
+    replace_triggered_by = [data.local_file.lambda_processor_zip_file.id]
+  }
+
   environment {
     variables = {
       DEBUG               = var.kmslog_lambda_debug ? "1" : ""
@@ -1105,6 +1117,10 @@ resource "aws_lambda_function" "event_processor" {
   handler       = "main.IdentityKMSMonitor::CloudWatchEventGenerator.process"
   runtime       = "ruby3.2"
   timeout       = 120 # seconds
+
+  lifecycle {
+    replace_triggered_by = [data.local_file.lambda_processor_zip_file.id]
+  }
 
   environment {
     variables = {

--- a/versions.tf
+++ b/versions.tf
@@ -15,6 +15,9 @@ terraform {
     null = {
       source = "hashicorp/null"
     }
+    local = {
+      source = "hashicorp/local"
+    }
     github = {
       source = "integrations/github"
     }


### PR DESCRIPTION
###  Updating KMS Matching to Ruby 3.2 Runtimes

This PR modifies our KMS Matching Lambdas to use the latest ruby runtime available. 
