### PR TITLE
Replicate and Update-Primary-Region Replica Key Event Monitoring

### DIFF
--- a/kms_keymaker_multiregion_replica/cloudwatch.tf
+++ b/kms_keymaker_multiregion_replica/cloudwatch.tf
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_event_rule" "replicate" {
     "eventName": ["ReplicateKey"],
     "eventSource": ["kms.amazonaws.com"],
     "requestParameters": {
-        "keyId": [ "${aws_kms_key.login_dot_gov_keymaker_multi_region.key_id}" ],
+        "keyId": [ "${aws_kms_replica_key.login_dot_gov_keymaker_multi_region_replica.key_id}" ],
         "replicaRegion": [
             {
                 "anything-but": [
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_event_rule" "update_primary_region" {
     "eventName": ["UpdatePrimaryRegion"],
     "eventSource": ["kms.amazonaws.com"],
     "requestParameters": {
-        "keyId": [ "${aws_kms_key.login_dot_gov_keymaker_multi_region.key_id}" ],
+        "keyId": [ "${aws_kms_replica_key.login_dot_gov_keymaker_multi_region_replica.key_id}" ],
         "replicaRegion": [
             {
                 "anything-but": [

--- a/kms_keymaker_multiregion_replica/cloudwatch.tf
+++ b/kms_keymaker_multiregion_replica/cloudwatch.tf
@@ -39,3 +39,51 @@ resource "aws_cloudwatch_event_rule" "decrypt" {
 PATTERN
 
 }
+
+# https://docs.aws.amazon.com/kms/latest/developerguide/ct-replicate-key.html
+resource "aws_cloudwatch_event_rule" "replicate" {
+  name        = "${var.env_name}-mr-replicate-events"
+  description = "Capture disallowed replicate events"
+
+  event_pattern = <<PATTERN
+{
+    "eventName": ["ReplicateKey"],
+    "eventSource": ["kms.amazonaws.com"],
+    "requestParameters": {
+        "keyId": [ "${aws_kms_key.login_dot_gov_keymaker_multi_region.key_id}" ],
+        "replicaRegion": [
+            {
+                "anything-but": [
+                    "us-west-2",
+                    "us-east-1"
+                ]
+            }
+        ] 
+    }
+}
+PATTERN
+}
+
+# https://docs.aws.amazon.com/kms/latest/developerguide/ct-update-primary-region.html
+resource "aws_cloudwatch_event_rule" "update_primary_region" {
+  name        = "${var.env_name}-mr-update-primary-region-events"
+  description = "Capture disallowed update primary region events"
+
+  event_pattern = <<PATTERN
+{
+    "eventName": ["UpdatePrimaryRegion"],
+    "eventSource": ["kms.amazonaws.com"],
+    "requestParameters": {
+        "keyId": [ "${aws_kms_key.login_dot_gov_keymaker_multi_region.key_id}" ],
+        "replicaRegion": [
+            {
+                "anything-but": [
+                    "us-west-2",
+                    "us-east-1"
+                ]
+            }
+        ] 
+    }
+}
+PATTERN
+}


### PR DESCRIPTION
### Replicate and Update-Primary-Region Replica Key Event Monitoring

This PR adds additional monitoring  to KMS Multi-Region Replica keys to prevent the promotion and replication of replica keys to primary without notification. As well as the replication after promotion.

Addresses #N/A