### PR TITLE
Removing KMS Log replace_by_trigger due to cycling error

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -20,10 +20,6 @@ locals {
 data "aws_caller_identity" "current" {
 }
 
-data "local_file" "lambda_processor_zip_file" {
-  filename = var.lambda_kms_cw_processor_zip
-}
-
 data "aws_iam_policy_document" "kms" {
   # Allow root users in
   statement {
@@ -795,10 +791,6 @@ resource "aws_lambda_function" "cloudtrail_processor" {
   runtime       = "ruby3.2"
   timeout       = 120 # seconds
 
-  lifecycle {
-    replace_triggered_by = [data.local_file.lambda_processor_zip_file.id]
-  }
-
   environment {
     variables = {
       DEBUG               = var.kmslog_lambda_debug ? "1" : ""
@@ -980,10 +972,6 @@ resource "aws_lambda_function" "cloudwatch_processor" {
   runtime       = "ruby3.2"
   timeout       = 120 # seconds
 
-  lifecycle {
-    replace_triggered_by = [data.local_file.lambda_processor_zip_file.id]
-  }
-
   memory_size = var.cw_processor_memory_size
 
   ephemeral_storage {
@@ -1124,10 +1112,6 @@ resource "aws_lambda_function" "event_processor" {
   handler       = "main.IdentityKMSMonitor::CloudWatchEventGenerator.process"
   runtime       = "ruby3.2"
   timeout       = 120 # seconds
-
-  lifecycle {
-    replace_triggered_by = [data.local_file.lambda_processor_zip_file.id]
-  }
 
   environment {
     variables = {


### PR DESCRIPTION
### Removing KMS Log replace_by_trigger due to cycling error

This PR does what is says on the title. After applying the latest version of KMS Log, secondary applies result in a cycling error between the local_file and lambda resources. 