### PR TITLE
Enable Lambda Insights for KMS Log Module

### DIFF
--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -14,7 +14,7 @@ locals {
 
   lambda_env_variables = merge(local.default_variables, local.alarm_variables)
 
-  lambda_insights = "arn:aws:lambda:${var.region}:580247275435:layer:LambdaInsightsExtension:${var.lambda_insights_version}"
+  lambda_insights = "arn:aws:lambda:${var.region}:${var.lambda_insights_account}:layer:LambdaInsightsExtension:${var.lambda_insights_version}"
 
 }
 

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -14,7 +14,7 @@ locals {
 
   lambda_env_variables = merge(local.default_variables, local.alarm_variables)
 
-  lambda_insights = "arn:aws:lambda:${var.region}:580247275435:layer:LambdaInsightsExtension:38"
+  lambda_insights = "arn:aws:lambda:${var.region}:580247275435:layer:LambdaInsightsExtension:${var.lambda_insights_version}"
 
 }
 

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -292,8 +292,8 @@ resource "aws_lambda_event_source_mapping" "sqs_to_batch_processor" {
 }
 
 module "slack-processor-github-alerts" {
-  #source = "github.com/18F/identity-terraform//lambda_alerts?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
-  source = "../lambda_alerts"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=ac06f87c59ad7e4e95c94b8e0637365cb5592017"
+  #source = "../lambda_alerts"
 
   enabled              = 1
   function_name        = local.slack_processor_lambda_name
@@ -827,8 +827,8 @@ resource "aws_lambda_function" "cloudtrail_processor" {
 }
 
 module "ct-processor-github-alerts" {
-  #source = "github.com/18F/identity-terraform//lambda_alerts?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
-  source = "../lambda_alerts"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=ac06f87c59ad7e4e95c94b8e0637365cb5592017"
+  #source = "../lambda_alerts"
 
   enabled              = 1
   function_name        = local.ct_processor_lambda_name
@@ -1023,8 +1023,8 @@ resource "aws_lambda_function" "cloudwatch_processor" {
 }
 
 module "cw-processor-github-alerts" {
-  #source = "github.com/18F/identity-terraform//lambda_alerts?ref=91f5c8a84c664fc5116ef970a5896c2edadff2b1"
-  source = "../lambda_alerts"
+  source = "github.com/18F/identity-terraform//lambda_alerts?ref=ac06f87c59ad7e4e95c94b8e0637365cb5592017"
+  #source = "../lambda_alerts"
 
   enabled              = 1
   function_name        = local.cw_processor_lambda_name

--- a/kms_log/main.tf
+++ b/kms_log/main.tf
@@ -10,11 +10,9 @@ locals {
     log_group_name = aws_cloudwatch_log_group.unmatched.name
   }
 
-  alarm_variables = length(var.alarm_sns_topic_arns) > 0 ? { arn = var.alarm_sns_topic_arns[0] } : {}
-
+  alarm_variables      = length(var.alarm_sns_topic_arns) > 0 ? { arn = var.alarm_sns_topic_arns[0] } : {}
   lambda_env_variables = merge(local.default_variables, local.alarm_variables)
-
-  lambda_insights = "arn:aws:lambda:${var.region}:${var.lambda_insights_account}:layer:LambdaInsightsExtension:${var.lambda_insights_version}"
+  lambda_insights      = "arn:aws:lambda:${var.region}:${var.lambda_insights_account}:layer:LambdaInsightsExtension:${var.lambda_insights_version}"
 
 }
 

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -86,6 +86,12 @@ variable "alarm_sns_topic_arns" {
   default     = []
 }
 
+variable "lambda_insights_version" {
+  description = "The lambda insights layer version to use for monitoring"
+  type        = number
+  default     = 38
+}
+
 ## Lambda KMS CloudWatch Processor Configuration
 
 variable "lambda_kms_cw_processor_zip" {

--- a/kms_log/variables.tf
+++ b/kms_log/variables.tf
@@ -86,6 +86,12 @@ variable "alarm_sns_topic_arns" {
   default     = []
 }
 
+variable "lambda_insights_account" {
+  description = "The lambda insights account provided by AWS for monitoring"
+  type        = string
+  default     = "580247275435"
+}
+
 variable "lambda_insights_version" {
   description = "The lambda insights layer version to use for monitoring"
   type        = number

--- a/lambda_alerts/main.tf
+++ b/lambda_alerts/main.tf
@@ -54,6 +54,7 @@ locals {
     for layer in local.layers : strcontains(layer, local.insights_layer_name)
   ])
   layers = data.aws_lambda_function.target.layers
+
 }
 
 data "aws_lambda_function" "target" {


### PR DESCRIPTION
### Enable Lambda Insights for KMS Log Module

This PR enables Lambda Insights for KMS Log Module! In turn, this provides [useful performance metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-metrics.html) and memory alarms! Please note, sources for lambda_alerts will be updated to the corresponding  git SHA prior to merging.

_Related PRs:_

- https://github.com/18F/identity-terraform/pull/188
- https://github.com/18F/identity-devops/pull/6572

Partially Addresses #https://github.com/18F/identity-devops/issues/5916

