### PR TITLE
Allow optional description; fix JSON fixture

### DIFF
--- a/slo_lambda/src/windowed_slo.py
+++ b/slo_lambda/src/windowed_slo.py
@@ -161,6 +161,7 @@ class SLI:
         self,
         numerator: List[Dict],
         denominator: List[Dict],
+        description: str = "",
         window_days: int = WINDOW_DAYS,
     ):
         if window_days is None:

--- a/slo_lambda/src/windowed_slo_fixture_happy.json
+++ b/slo_lambda/src/windowed_slo_fixture_happy.json
@@ -96,7 +96,7 @@
           }
         ]
       }
-    ]
+    ],
     "denominator": [
       {
         "namespace": "test/sli",


### PR DESCRIPTION
Fixes a couple small bugs that are preventing us from collecting availability and latency SLIs. Tested in `akrito` sandbox (this errored before, now calculates `*_availability` and `*_latency`):

```
START RequestId: 0c8a189c-6cdb-4aeb-93d1-8b56d3cfa822 Version: $LATEST
all_availability: 1.000000
interesting_availability: 1.000000
interesting_latency: 0.901408
END RequestId: 0c8a189c-6cdb-4aeb-93d1-8b56d3cfa822
REPORT RequestId: 0c8a189c-6cdb-4aeb-93d1-8b56d3cfa822	Duration: 4252.73 ms	Billed Duration: 4253 ms	Memory Size: 128 MB	Max Memory Used: 72 MB	Init Duration: 306.32 ms	
```
